### PR TITLE
Add automatic image deployment to Cloud Build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -62,9 +62,26 @@ steps:
         docker push ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY_REPO}/${_SERVICE_NAME}:${SHORT_SHA}
         docker push ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY_REPO}/${_SERVICE_NAME}:latest
 
-  # Note: Cloud Run deployment is managed by Terraform
-  # After image is pushed, trigger Terraform apply to update the service
-  # See: recipe-management-infrastructure/terraform/environments/dev/main.tf
+  # Deploy new image to Cloud Run - ONLY on main branch
+  # Note: Only updates the image, other config managed by Terraform
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    id: 'deploy-backend'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        # Only deploy on main branch
+        if [ "$BRANCH_NAME" != "main" ]; then
+          echo "PR build detected (branch: $BRANCH_NAME), skipping deployment"
+          exit 0
+        fi
+        
+        echo "Deploying new image to Cloud Run..."
+        gcloud run services update ${_SERVICE_NAME} \
+          --image ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY_REPO}/${_SERVICE_NAME}:latest \
+          --region ${_REGION}
+        
+        echo "Deployment complete ✓"
 
 # Substitutions for different environments
 substitutions:


### PR DESCRIPTION
## Changes

Adds deployment step back to Cloud Build that automatically updates the Cloud Run service with the new image after push.

## Why

After PR #2 removed deployment, images were built and pushed but never deployed automatically. This restores automatic deployment while maintaining Terraform as the source of truth for configuration.

## How It Works

```yaml
gcloud run services update recipe-ai-service \
  --image <new-image> \
  --region europe-west2
```

**Key:** Only updates the **image**, not CPU/memory/env vars/etc.

## Benefits

- ✅ Automatic deployment on merge to main
- ✅ Terraform still owns configuration
- ✅ Fast deployments

## Related

- Storage Service PR #15: Same approach (already merged)