### PR TITLE
Add local Maven repository path to build steps

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -116,6 +116,7 @@ steps:
     args:
       - '-s'
       - '/workspace/.m2/settings.xml'
+      - '-Dmaven.repo.local=/workspace/.m2/repo'
       - 'test'
 
   # Run linting (Checkstyle, SpotBugs, PMD)
@@ -125,6 +126,7 @@ steps:
     args:
       - '-s'
       - '/workspace/.m2/settings.xml'
+      - '-Dmaven.repo.local=/workspace/.m2/repo'
       - 'verify'
       - '-DskipTests'
 
@@ -137,7 +139,7 @@ steps:
       - |
         VERSION=$$(cat /workspace/version.txt)
         echo "Building application package with version: $${VERSION}"
-        mvn -s /workspace/.m2/settings.xml package -DskipTests
+        mvn -s /workspace/.m2/settings.xml -Dmaven.repo.local=/workspace/.m2/repo package -DskipTests
 
   # Build Docker image - ONLY on main branch
   - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
This pull request updates the Maven build steps in the `cloudbuild.yaml` file to explicitly set the local Maven repository location. This change helps ensure that Maven dependencies are cached and managed in a consistent location during builds, which can improve build reliability and performance in CI environments.

**Build process improvements:**

* Added the `-Dmaven.repo.local=/workspace/.m2/repo` argument to the Maven `test` step to specify the local repository path.
* Added the `-Dmaven.repo.local=/workspace/.m2/repo` argument to the Maven `verify` step (with `-DskipTests`) to use the same local repository path.
* Updated the Maven `package` step to include the `-Dmaven.repo.local=/workspace/.m2/repo` argument, ensuring all build phases use the same local repository.