### PR TITLE
fix: revert Spring Boot version from 4.0.0 to 3.5.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,13 +178,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Spring Boot Web Test (includes MockMvc for Spring Boot 4.x) -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <!-- Use OkHttp MockWebServer for lightweight HTTP stubbing in integration tests -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>


### PR DESCRIPTION
## Problem
Spring Boot 4.0.0 does not exist yet. The version was accidentally set to 4.0.0 instead of the intended 3.5.8, causing compilation failures:

- Missing package: `org.springframework.boot.test.autoconfigure.web.servlet`
- Missing annotation: `@AutoConfigureMockMvc`
- Multiple missing artifacts in dependency tree

## Solution
Revert Spring Boot parent version to 3.5.8, which is the latest stable release.

## Testing
CI build should pass with all tests compiling and running successfully.

Fixes the main branch build failure.