### PR TITLE
fix(ci): stop using GIT_PAT for checkout

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 2
-        token: ${{ secrets.GIT_PAT }}
+        token: ${{ github.token }}
 
     - name: Set up JDK 21
       uses: actions/setup-java@v5
@@ -278,7 +278,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 2
-        token: ${{ secrets.GIT_PAT }}
+        token: ${{ github.token }}
 
     - name: Prepare next development version
       run: |


### PR DESCRIPTION
## Summary
PRs in `recipe-management-ai-service` are failing at checkout with:
- `fatal: could not read Username for 'https://github.com': terminal prompts disabled`

## Root cause
The workflow overrides checkout auth with `secrets.GIT_PAT`. If that secret is missing or expired, `actions/checkout` fails before the build starts.

## Change
In `.github/workflows/ci-cd.yml`, replaced both checkout token overrides:
- `token: ${{ secrets.GIT_PAT }}`
- -> `token: ${{ github.token }}`

## Why this fixes all PRs
`github.token` is always provisioned by Actions for the run, so checkout no longer depends on a rotatable PAT secret.
