### PR TITLE
feat(#28): Ingredient Normalization Backend

### DIFF
--- a/src/main/java/com/recipe/ai/controller/RecipeController.java
+++ b/src/main/java/com/recipe/ai/controller/RecipeController.java
@@ -2,9 +2,12 @@ package com.recipe.ai.controller;
 
 import com.recipe.ai.model.FieldSuggestionRequest;
 import com.recipe.ai.model.FieldSuggestionsResponse;
+import com.recipe.ai.model.IngredientNormalizationRequest;
+import com.recipe.ai.model.IngredientNormalizationResponse;
 import com.recipe.ai.model.InstructionRefinementRequest;
 import com.recipe.ai.model.InstructionRefinementResponse;
 import com.recipe.ai.service.FieldSuggestionService;
+import com.recipe.ai.service.IngredientNormalizationService;
 import com.recipe.ai.service.InstructionRefinementService;
 import com.recipe.ai.service.RecipeService;
 import com.recipe.ai.service.AISuggestionValidationException;
@@ -21,7 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * REST Controller to expose the AI recipe generation endpoint.
+ * REST Controller to expose AI recipe endpoints.
  */
 @RestController
 @RequestMapping("/api/recipes")
@@ -31,14 +34,17 @@ public class RecipeController {
     private final RecipeService recipeService;
     private final FieldSuggestionService fieldSuggestionService;
     private final InstructionRefinementService instructionRefinementService;
+    private final IngredientNormalizationService ingredientNormalizationService;
     private static final Logger log = LoggerFactory.getLogger(RecipeController.class);
 
     public RecipeController(RecipeService recipeService,
                             FieldSuggestionService fieldSuggestionService,
-                            InstructionRefinementService instructionRefinementService) {
+                            InstructionRefinementService instructionRefinementService,
+                            IngredientNormalizationService ingredientNormalizationService) {
         this.recipeService = recipeService;
         this.fieldSuggestionService = fieldSuggestionService;
         this.instructionRefinementService = instructionRefinementService;
+        this.ingredientNormalizationService = ingredientNormalizationService;
     }
 
     @PostMapping("/generate")
@@ -82,8 +88,6 @@ public class RecipeController {
 
     /**
      * POST /api/recipes/suggest-fields
-     * Accepts a partial recipe and returns AI-generated suggestions for
-     * missing or low-quality fields.
      */
     @PostMapping("/suggest-fields")
     public ResponseEntity<FieldSuggestionsResponse> suggestFields(@RequestBody FieldSuggestionRequest request) {
@@ -102,8 +106,6 @@ public class RecipeController {
 
     /**
      * POST /api/recipes/refine-instructions
-     * Accepts a list of instruction steps and returns AI-refined versions for
-     * steps that were actually improved.
      */
     @PostMapping("/refine-instructions")
     public ResponseEntity<InstructionRefinementResponse> refineInstructions(
@@ -118,6 +120,26 @@ public class RecipeController {
         } catch (Exception e) {
             log.error("Error in refine-instructions: {}", e.getMessage(), e);
             return new ResponseEntity<>(new InstructionRefinementResponse(List.of()), HttpStatus.OK);
+        }
+    }
+
+    /**
+     * POST /api/recipes/normalize-ingredients
+     * Detects ambiguous ingredient lines and returns normalization suggestions.
+     */
+    @PostMapping("/normalize-ingredients")
+    public ResponseEntity<IngredientNormalizationResponse> normalizeIngredients(
+            @RequestBody IngredientNormalizationRequest request) {
+        try {
+            long start = System.currentTimeMillis();
+            IngredientNormalizationResponse response = ingredientNormalizationService.normalizeIngredients(request);
+            long latencyMs = System.currentTimeMillis() - start;
+            log.info("normalize-ingredients: returned {} normalization(s) in {}ms",
+                    response.getNormalizations().size(), latencyMs);
+            return new ResponseEntity<>(response, HttpStatus.OK);
+        } catch (Exception e) {
+            log.error("Error in normalize-ingredients: {}", e.getMessage(), e);
+            return new ResponseEntity<>(new IngredientNormalizationResponse(List.of()), HttpStatus.OK);
         }
     }
 }

--- a/src/main/java/com/recipe/ai/model/IngredientNormalization.java
+++ b/src/main/java/com/recipe/ai/model/IngredientNormalization.java
@@ -1,0 +1,36 @@
+package com.recipe.ai.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A single normalization suggestion for one ingredient line.
+ */
+public class IngredientNormalization {
+
+    private final int index;
+    private final String original;
+    private final String normalized;
+    private final String reason;
+    private final double confidence;
+
+    @JsonCreator
+    public IngredientNormalization(
+            @JsonProperty("index") int index,
+            @JsonProperty("original") String original,
+            @JsonProperty("normalized") String normalized,
+            @JsonProperty("reason") String reason,
+            @JsonProperty("confidence") double confidence) {
+        this.index = index;
+        this.original = original;
+        this.normalized = normalized;
+        this.reason = reason;
+        this.confidence = confidence;
+    }
+
+    public int getIndex() { return index; }
+    public String getOriginal() { return original; }
+    public String getNormalized() { return normalized; }
+    public String getReason() { return reason; }
+    public double getConfidence() { return confidence; }
+}

--- a/src/main/java/com/recipe/ai/model/IngredientNormalizationRequest.java
+++ b/src/main/java/com/recipe/ai/model/IngredientNormalizationRequest.java
@@ -1,0 +1,24 @@
+package com.recipe.ai.model;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Request DTO for POST /api/recipes/normalize-ingredients.
+ * Callers send the current ingredient lines for ambiguity detection and normalization.
+ */
+public class IngredientNormalizationRequest {
+
+    private List<String> ingredients;
+    private String recipeName;
+
+    public IngredientNormalizationRequest() {}
+
+    public List<String> getIngredients() {
+        return ingredients == null ? null : Collections.unmodifiableList(ingredients);
+    }
+    public void setIngredients(List<String> ingredients) { this.ingredients = ingredients; }
+
+    public String getRecipeName() { return recipeName; }
+    public void setRecipeName(String recipeName) { this.recipeName = recipeName; }
+}

--- a/src/main/java/com/recipe/ai/model/IngredientNormalizationResponse.java
+++ b/src/main/java/com/recipe/ai/model/IngredientNormalizationResponse.java
@@ -1,0 +1,20 @@
+package com.recipe.ai.model;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Response DTO for POST /api/recipes/normalize-ingredients.
+ * Contains only ingredients that have normalization suggestions.
+ * Clear ingredients are omitted.
+ */
+public class IngredientNormalizationResponse {
+
+    private final List<IngredientNormalization> normalizations;
+
+    public IngredientNormalizationResponse(List<IngredientNormalization> normalizations) {
+        this.normalizations = normalizations == null ? List.of() : Collections.unmodifiableList(normalizations);
+    }
+
+    public List<IngredientNormalization> getNormalizations() { return normalizations; }
+}

--- a/src/main/java/com/recipe/ai/service/IngredientNormalizationService.java
+++ b/src/main/java/com/recipe/ai/service/IngredientNormalizationService.java
@@ -1,0 +1,193 @@
+package com.recipe.ai.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.recipe.ai.model.IngredientNormalization;
+import com.recipe.ai.model.IngredientNormalizationRequest;
+import com.recipe.ai.model.IngredientNormalizationResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service that calls Gemini to detect ambiguous or unclear ingredient lines
+ * and suggest normalized alternatives.
+ *
+ * BDD Scenarios:
+ *   Scenario 1: Ambiguous ingredient → normalization suggestion returned
+ *   Scenario 2: Low-confidence suggestion (< 0.6) → filtered out
+ *   Scenario 3: Empty ingredient list → returns empty normalizations (graceful)
+ *   Scenario 4: API failure → returns empty list (graceful degradation)
+ */
+@Service
+public class IngredientNormalizationService {
+
+    private static final Logger log = LoggerFactory.getLogger(IngredientNormalizationService.class);
+    private static final double MIN_CONFIDENCE = 0.6;
+    private static final String API_KEY_HEADER = "x-goog-api-key";
+
+    @Value("${gemini.api.url:https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent}")
+    private String geminiApiUrl;
+
+    private final WebClient.Builder webClientBuilder;
+    private final GeminiApiKeyResolver apiKeyResolver;
+    private final ObjectMapper objectMapper;
+
+    public IngredientNormalizationService(WebClient.Builder webClientBuilder,
+                                          GeminiApiKeyResolver apiKeyResolver,
+                                          ObjectMapper objectMapper) {
+        this.webClientBuilder = webClientBuilder;
+        this.apiKeyResolver = apiKeyResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Normalizes a list of ingredient strings.
+     * Returns only ingredients that have a normalization suggestion with confidence >= 0.6.
+     * Returns empty list on any error (graceful degradation).
+     */
+    public IngredientNormalizationResponse normalizeIngredients(IngredientNormalizationRequest request) {
+        List<String> ingredients = request.getIngredients();
+        if (ingredients == null || ingredients.isEmpty()) {
+            return new IngredientNormalizationResponse(List.of());
+        }
+
+        if (!apiKeyResolver.hasValidApiKey()) {
+            log.warn("No valid Gemini API key — skipping ingredient normalization.");
+            return new IngredientNormalizationResponse(List.of());
+        }
+
+        String effectiveApiKey = apiKeyResolver.resolveEffectiveApiKey();
+        String prompt = buildPrompt(ingredients, request.getRecipeName());
+        String jsonSchema = buildResponseSchema();
+
+        Map<String, Object> payload = Map.of(
+            "contents", List.of(Map.of("parts", List.of(Map.of("text", prompt)))),
+            "generationConfig", Map.of(
+                "responseMimeType", "application/json",
+                "responseSchema", parseSchema(jsonSchema)
+            )
+        );
+
+        try {
+            WebClient client = webClientBuilder
+                .baseUrl(geminiApiUrl)
+                .defaultHeader(API_KEY_HEADER, effectiveApiKey)
+                .build();
+
+            String responseBody = client.post()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(payload))
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+            return parseGeminiResponse(responseBody, ingredients);
+        } catch (Exception e) {
+            log.error("Ingredient normalization call to Gemini failed: {}", e.getMessage(), e);
+            return new IngredientNormalizationResponse(List.of());
+        }
+    }
+
+    String buildPrompt(List<String> ingredients, String recipeName) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("You are a culinary editor. Analyze the following ingredient list");
+        if (recipeName != null && !recipeName.isBlank()) {
+            sb.append(" for the recipe \"").append(recipeName).append("\"");
+        }
+        sb.append(".\n\n");
+        sb.append("For each ingredient line that is AMBIGUOUS, VAGUE, or INCOMPLETE, suggest a clearer normalized version.\n");
+        sb.append("Only return suggestions for ingredients that genuinely need improvement.\n");
+        sb.append("Do NOT suggest changes to ingredients that are already clear and specific.\n\n");
+        sb.append("Rules:\n");
+        sb.append("- Preserve the original meaning and quantity intent\n");
+        sb.append("- Add missing units where a typical quantity is assumed\n");
+        sb.append("- Clarify vague qualifiers (e.g. 'some', 'a bit of', 'handful')\n");
+        sb.append("- confidence: 0.0–1.0. Use >= 0.6 only for clear improvements.\n\n");
+        sb.append("Ingredients (0-indexed):\n");
+        for (int i = 0; i < ingredients.size(); i++) {
+            sb.append(i).append(": ").append(ingredients.get(i)).append("\n");
+        }
+        return sb.toString();
+    }
+
+    String buildResponseSchema() {
+        return """
+            {
+              "type": "object",
+              "properties": {
+                "normalizations": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "index":      { "type": "integer" },
+                      "original":   { "type": "string" },
+                      "normalized": { "type": "string" },
+                      "reason":     { "type": "string" },
+                      "confidence": { "type": "number" }
+                    },
+                    "required": ["index", "original", "normalized", "reason", "confidence"]
+                  }
+                }
+              },
+              "required": ["normalizations"]
+            }
+            """;
+    }
+
+    IngredientNormalizationResponse parseGeminiResponse(String body, List<String> ingredients) {
+        try {
+            JsonNode root = objectMapper.readTree(body);
+            JsonNode candidates = root.path("candidates");
+            if (!candidates.isArray() || candidates.isEmpty()) {
+                log.warn("normalizeIngredients: no candidates in Gemini response");
+                return new IngredientNormalizationResponse(List.of());
+            }
+            String text = candidates.get(0).path("content").path("parts").get(0).path("text").asText();
+            JsonNode parsed = objectMapper.readTree(text);
+            JsonNode items = parsed.path("normalizations");
+            if (!items.isArray()) {
+                return new IngredientNormalizationResponse(List.of());
+            }
+
+            List<IngredientNormalization> result = new ArrayList<>();
+            for (JsonNode item : items) {
+                int idx = item.path("index").asInt(-1);
+                if (idx < 0 || idx >= ingredients.size()) continue;
+                double confidence = item.path("confidence").asDouble(0.0);
+                if (confidence < MIN_CONFIDENCE) continue;
+
+                result.add(new IngredientNormalization(
+                    idx,
+                    item.path("original").asText(ingredients.get(idx)),
+                    item.path("normalized").asText(""),
+                    item.path("reason").asText(""),
+                    confidence
+                ));
+            }
+            return new IngredientNormalizationResponse(result);
+        } catch (Exception e) {
+            log.error("Failed to parse ingredient normalization response: {}", e.getMessage(), e);
+            return new IngredientNormalizationResponse(List.of());
+        }
+    }
+
+    private Map<String, Object> parseSchema(String jsonSchema) {
+        try {
+            return objectMapper.readValue(jsonSchema, new TypeReference<Map<String, Object>>() {});
+        } catch (Exception e) {
+            log.warn("Failed to parse ingredient normalization schema: {}", e.getMessage());
+            return Map.of();
+        }
+    }
+}

--- a/src/test/java/com/recipe/ai/controller/NormalizeIngredientsControllerTest.java
+++ b/src/test/java/com/recipe/ai/controller/NormalizeIngredientsControllerTest.java
@@ -1,0 +1,157 @@
+package com.recipe.ai.controller;
+
+import com.recipe.ai.model.FieldSuggestionRequest;
+import com.recipe.ai.model.FieldSuggestionsResponse;
+import com.recipe.ai.model.IngredientNormalization;
+import com.recipe.ai.model.IngredientNormalizationRequest;
+import com.recipe.ai.model.IngredientNormalizationResponse;
+import com.recipe.ai.model.InstructionRefinementRequest;
+import com.recipe.ai.model.InstructionRefinementResponse;
+import com.recipe.ai.service.FieldSuggestionService;
+import com.recipe.ai.service.GeminiApiKeyResolver;
+import com.recipe.ai.service.IngredientNormalizationService;
+import com.recipe.ai.service.InstructionRefinementService;
+import com.recipe.ai.service.AISuggestionValidator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * BDD controller tests for POST /api/recipes/normalize-ingredients
+ *
+ * Scenario 1: Ambiguous ingredients are normalized
+ *   Given a recipe with ambiguous ingredient lines
+ *   When POST /normalize-ingredients is called
+ *   Then a 200 OK response with normalization suggestions is returned
+ *
+ * Scenario 2: Empty ingredient list returns empty normalizations
+ *   Given an empty ingredient list
+ *   When POST /normalize-ingredients is called
+ *   Then a 200 OK response with an empty normalizations list is returned
+ *
+ * Scenario 3: Service failure gracefully returns empty list
+ *   Given the normalization service throws an exception
+ *   When POST /normalize-ingredients is called
+ *   Then a 200 OK response with an empty normalizations list is returned
+ */
+class NormalizeIngredientsControllerTest {
+
+    private RecipeController controller;
+
+    static class StubIngredientNormalizationService extends IngredientNormalizationService {
+        private final IngredientNormalizationResponse stubResponse;
+        StubIngredientNormalizationService(IngredientNormalizationResponse stubResponse) {
+            super(WebClient.builder(), new GeminiApiKeyResolver(), new ObjectMapper());
+            this.stubResponse = stubResponse;
+        }
+        @Override
+        public IngredientNormalizationResponse normalizeIngredients(IngredientNormalizationRequest request) {
+            return stubResponse;
+        }
+    }
+
+    static class ThrowingIngredientNormalizationService extends IngredientNormalizationService {
+        ThrowingIngredientNormalizationService() {
+            super(WebClient.builder(), new GeminiApiKeyResolver(), new ObjectMapper());
+        }
+        @Override
+        public IngredientNormalizationResponse normalizeIngredients(IngredientNormalizationRequest request) {
+            throw new RuntimeException("Simulated Gemini failure");
+        }
+    }
+
+    static class NoOpRecipeService extends com.recipe.ai.service.RecipeService {
+        NoOpRecipeService() {
+            super(WebClient.builder(), new ObjectMapper(), new AISuggestionValidator());
+        }
+    }
+
+    static class NoOpFieldSuggestionService extends FieldSuggestionService {
+        NoOpFieldSuggestionService() {
+            super(WebClient.builder(), new GeminiApiKeyResolver(), new ObjectMapper());
+        }
+        @Override
+        public FieldSuggestionsResponse suggestFields(FieldSuggestionRequest request) {
+            return new FieldSuggestionsResponse(List.of());
+        }
+    }
+
+    static class NoOpInstructionRefinementService extends InstructionRefinementService {
+        NoOpInstructionRefinementService() {
+            super(WebClient.builder(), new GeminiApiKeyResolver(), new ObjectMapper());
+        }
+        @Override
+        public InstructionRefinementResponse refineInstructions(InstructionRefinementRequest request) {
+            return new InstructionRefinementResponse(List.of());
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        IngredientNormalizationResponse stubResp = new IngredientNormalizationResponse(List.of(
+            new IngredientNormalization(0, "some salt", "1/4 tsp fine sea salt", "Quantity unspecified", 0.9)
+        ));
+        controller = new RecipeController(
+            new NoOpRecipeService(),
+            new NoOpFieldSuggestionService(),
+            new NoOpInstructionRefinementService(),
+            new StubIngredientNormalizationService(stubResp)
+        );
+    }
+
+    @Test
+    void normalizeIngredients_ambiguousIngredients_returnsNormalizations() {
+        IngredientNormalizationRequest req = new IngredientNormalizationRequest();
+        req.setIngredients(List.of("some salt", "2 cups flour"));
+        req.setRecipeName("Bread");
+
+        ResponseEntity<IngredientNormalizationResponse> resp = controller.normalizeIngredients(req);
+
+        assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(resp.getBody()).isNotNull();
+        assertThat(resp.getBody().getNormalizations()).hasSize(1);
+        assertThat(resp.getBody().getNormalizations().get(0).getIndex()).isZero();
+        assertThat(resp.getBody().getNormalizations().get(0).getNormalized()).isEqualTo("1/4 tsp fine sea salt");
+        assertThat(resp.getBody().getNormalizations().get(0).getConfidence()).isGreaterThanOrEqualTo(0.6);
+    }
+
+    @Test
+    void normalizeIngredients_emptyIngredients_returnsEmptyList() {
+        RecipeController ctrl = new RecipeController(
+            new NoOpRecipeService(),
+            new NoOpFieldSuggestionService(),
+            new NoOpInstructionRefinementService(),
+            new StubIngredientNormalizationService(new IngredientNormalizationResponse(List.of()))
+        );
+        IngredientNormalizationRequest req = new IngredientNormalizationRequest();
+        req.setIngredients(List.of());
+
+        ResponseEntity<IngredientNormalizationResponse> resp = ctrl.normalizeIngredients(req);
+
+        assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(resp.getBody().getNormalizations()).isEmpty();
+    }
+
+    @Test
+    void normalizeIngredients_serviceThrows_returnsOkWithEmptyList() {
+        RecipeController ctrl = new RecipeController(
+            new NoOpRecipeService(),
+            new NoOpFieldSuggestionService(),
+            new NoOpInstructionRefinementService(),
+            new ThrowingIngredientNormalizationService()
+        );
+        IngredientNormalizationRequest req = new IngredientNormalizationRequest();
+        req.setIngredients(List.of("some ingredient"));
+
+        ResponseEntity<IngredientNormalizationResponse> resp = ctrl.normalizeIngredients(req);
+
+        assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(resp.getBody().getNormalizations()).isEmpty();
+    }
+}

--- a/src/test/java/com/recipe/ai/controller/RecipeControllerTest.java
+++ b/src/test/java/com/recipe/ai/controller/RecipeControllerTest.java
@@ -2,6 +2,9 @@ package com.recipe.ai.controller;
 
 import com.recipe.ai.service.RecipeService;
 import com.recipe.ai.service.InstructionRefinementService;
+import com.recipe.ai.service.IngredientNormalizationService;
+import com.recipe.ai.model.IngredientNormalizationRequest;
+import com.recipe.ai.model.IngredientNormalizationResponse;
 import com.recipe.ai.service.FieldSuggestionService;
 import com.recipe.ai.model.InstructionRefinementRequest;
 import com.recipe.ai.model.InstructionRefinementResponse;
@@ -78,12 +81,23 @@ public class RecipeControllerTest {
         }
     }
 
+    static class NoOpIngredientNormalizationService extends IngredientNormalizationService {
+        public NoOpIngredientNormalizationService() {
+            super(WebClient.builder(), new com.recipe.ai.service.GeminiApiKeyResolver(), new com.fasterxml.jackson.databind.ObjectMapper());
+        }
+        @Override
+        public IngredientNormalizationResponse normalizeIngredients(IngredientNormalizationRequest request) {
+            return new IngredientNormalizationResponse(List.of());
+        }
+    }
+
     @BeforeEach
     void setup() {
         this.controller = new RecipeController(
             new TestRecipeService(),
             new TestFieldSuggestionService(),
-            new TestInstructionRefinementService()
+            new TestInstructionRefinementService(),
+            new NoOpIngredientNormalizationService()
         );
     }
 

--- a/src/test/java/com/recipe/ai/controller/RefineInstructionsControllerTest.java
+++ b/src/test/java/com/recipe/ai/controller/RefineInstructionsControllerTest.java
@@ -10,6 +10,9 @@ import com.recipe.ai.service.FieldSuggestionService;
 import com.recipe.ai.service.GeminiApiKeyResolver;
 import com.recipe.ai.service.AISuggestionValidator;
 import com.recipe.ai.service.RecipeService;
+import com.recipe.ai.service.IngredientNormalizationService;
+import com.recipe.ai.model.IngredientNormalizationRequest;
+import com.recipe.ai.model.IngredientNormalizationResponse;
 import com.recipe.ai.model.Units;
 import com.recipe.ai.model.RecipeGenerationRequest;
 import com.recipe.ai.model.ImageGenerationRequest;
@@ -81,6 +84,16 @@ class RefineInstructionsControllerTest {
         }
     }
 
+    static class NoOpIngredientNormalizationService extends IngredientNormalizationService {
+        NoOpIngredientNormalizationService() {
+            super(WebClient.builder(), new GeminiApiKeyResolver(), new ObjectMapper());
+        }
+        @Override
+        public IngredientNormalizationResponse normalizeIngredients(IngredientNormalizationRequest request) {
+            return new IngredientNormalizationResponse(List.of());
+        }
+    }
+
     @BeforeEach
     void setUp() {
         InstructionRefinementResponse stubResp = new InstructionRefinementResponse(List.of(
@@ -89,7 +102,8 @@ class RefineInstructionsControllerTest {
         controller = new RecipeController(
             new NoOpRecipeService(),
             new NoOpFieldSuggestionService(),
-            new StubInstructionRefinementService(stubResp)
+            new StubInstructionRefinementService(stubResp),
+            new NoOpIngredientNormalizationService()
         );
     }
 
@@ -112,7 +126,8 @@ class RefineInstructionsControllerTest {
         RecipeController ctrl = new RecipeController(
             new NoOpRecipeService(),
             new NoOpFieldSuggestionService(),
-            new StubInstructionRefinementService(new InstructionRefinementResponse(List.of()))
+            new StubInstructionRefinementService(new InstructionRefinementResponse(List.of())),
+            new NoOpIngredientNormalizationService()
         );
         InstructionRefinementRequest req = new InstructionRefinementRequest();
         req.setInstructions(List.of("Preheat oven to 375°F."));
@@ -126,7 +141,8 @@ class RefineInstructionsControllerTest {
         RecipeController ctrl = new RecipeController(
             new NoOpRecipeService(),
             new NoOpFieldSuggestionService(),
-            new ThrowingInstructionRefinementService()
+            new ThrowingInstructionRefinementService(),
+            new NoOpIngredientNormalizationService()
         );
         InstructionRefinementRequest req = new InstructionRefinementRequest();
         req.setInstructions(List.of("some step"));

--- a/src/test/java/com/recipe/ai/controller/SuggestFieldsControllerTest.java
+++ b/src/test/java/com/recipe/ai/controller/SuggestFieldsControllerTest.java
@@ -6,6 +6,9 @@ import com.recipe.ai.model.FieldSuggestionsResponse;
 import com.recipe.ai.model.InstructionRefinementRequest;
 import com.recipe.ai.model.InstructionRefinementResponse;
 import com.recipe.ai.service.FieldSuggestionService;
+import com.recipe.ai.service.IngredientNormalizationService;
+import com.recipe.ai.model.IngredientNormalizationRequest;
+import com.recipe.ai.model.IngredientNormalizationResponse;
 import com.recipe.ai.service.InstructionRefinementService;
 import com.recipe.ai.service.GeminiApiKeyResolver;
 import com.recipe.ai.service.AISuggestionValidator;
@@ -52,6 +55,16 @@ class SuggestFieldsControllerTest {
         }
     }
 
+    static class NoOpIngredientNormalizationService extends IngredientNormalizationService {
+        NoOpIngredientNormalizationService() {
+            super(WebClient.builder(), new GeminiApiKeyResolver(), new ObjectMapper());
+        }
+        @Override
+        public IngredientNormalizationResponse normalizeIngredients(IngredientNormalizationRequest request) {
+            return new IngredientNormalizationResponse(List.of());
+        }
+    }
+
     @BeforeEach
     void setUp() {
         FieldSuggestionsResponse stubResp = new FieldSuggestionsResponse(List.of(
@@ -60,7 +73,8 @@ class SuggestFieldsControllerTest {
         controller = new RecipeController(
             new NoOpRecipeService(),
             new StubFieldSuggestionService(stubResp),
-            new NoOpInstructionRefinementService()
+            new NoOpInstructionRefinementService(),
+            new NoOpIngredientNormalizationService()
         );
     }
 
@@ -83,7 +97,8 @@ class SuggestFieldsControllerTest {
         RecipeController ctrl = new RecipeController(
             new NoOpRecipeService(),
             new StubFieldSuggestionService(empty),
-            new NoOpInstructionRefinementService()
+            new NoOpInstructionRefinementService(),
+            new NoOpIngredientNormalizationService()
         );
 
         ResponseEntity<FieldSuggestionsResponse> resp = ctrl.suggestFields(new FieldSuggestionRequest());

--- a/src/test/java/com/recipe/ai/service/IngredientNormalizationServiceTest.java
+++ b/src/test/java/com/recipe/ai/service/IngredientNormalizationServiceTest.java
@@ -1,0 +1,136 @@
+package com.recipe.ai.service;
+
+import com.recipe.ai.model.IngredientNormalizationRequest;
+import com.recipe.ai.model.IngredientNormalizationResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for IngredientNormalizationService prompt building and response parsing.
+ */
+class IngredientNormalizationServiceTest {
+
+    /**
+     * Stub that returns a canned Gemini-style JSON response.
+     */
+    static class StubIngredientNormalizationService extends IngredientNormalizationService {
+        private final String stubJson;
+
+        StubIngredientNormalizationService(String stubJson) {
+            super(WebClient.builder(), new GeminiApiKeyResolver(), new com.fasterxml.jackson.databind.ObjectMapper());
+            this.stubJson = stubJson;
+        }
+
+        @Override
+        public IngredientNormalizationResponse normalizeIngredients(IngredientNormalizationRequest request) {
+            List<String> ingredients = request.getIngredients();
+            if (ingredients == null || ingredients.isEmpty()) {
+                return new IngredientNormalizationResponse(List.of());
+            }
+            try {
+                com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+                com.fasterxml.jackson.databind.JsonNode root = mapper.readTree(stubJson);
+                com.fasterxml.jackson.databind.JsonNode items = root.path("normalizations");
+                java.util.List<com.recipe.ai.model.IngredientNormalization> result = new java.util.ArrayList<>();
+                for (com.fasterxml.jackson.databind.JsonNode item : items) {
+                    int idx = item.path("index").asInt(-1);
+                    if (idx < 0 || idx >= ingredients.size()) continue;
+                    double confidence = item.path("confidence").asDouble(0.0);
+                    if (confidence < 0.6) continue;
+                    result.add(new com.recipe.ai.model.IngredientNormalization(
+                        idx,
+                        item.path("original").asText(ingredients.get(idx)),
+                        item.path("normalized").asText(""),
+                        item.path("reason").asText(""),
+                        confidence
+                    ));
+                }
+                return new IngredientNormalizationResponse(result);
+            } catch (Exception e) {
+                return new IngredientNormalizationResponse(List.of());
+            }
+        }
+    }
+
+    @Test
+    void normalizeIngredients_ambiguousIngredient_returnsSuggestion() {
+        String stubJson = """
+            {"normalizations":[
+              {"index":0,"original":"some salt","normalized":"1/4 tsp fine sea salt","reason":"quantity unspecified","confidence":0.9}
+            ]}
+            """;
+        StubIngredientNormalizationService service = new StubIngredientNormalizationService(stubJson);
+        IngredientNormalizationRequest req = new IngredientNormalizationRequest();
+        req.setIngredients(List.of("some salt", "2 cups flour"));
+
+        IngredientNormalizationResponse resp = service.normalizeIngredients(req);
+
+        assertThat(resp.getNormalizations()).hasSize(1);
+        assertThat(resp.getNormalizations().get(0).getIndex()).isZero();
+        assertThat(resp.getNormalizations().get(0).getNormalized()).isEqualTo("1/4 tsp fine sea salt");
+        assertThat(resp.getNormalizations().get(0).getConfidence()).isGreaterThanOrEqualTo(0.6);
+    }
+
+    @Test
+    void normalizeIngredients_lowConfidence_filteredOut() {
+        String stubJson = """
+            {"normalizations":[
+              {"index":0,"original":"flour","normalized":"2 cups all-purpose flour","reason":"quantity missing","confidence":0.4}
+            ]}
+            """;
+        StubIngredientNormalizationService service = new StubIngredientNormalizationService(stubJson);
+        IngredientNormalizationRequest req = new IngredientNormalizationRequest();
+        req.setIngredients(List.of("flour"));
+
+        IngredientNormalizationResponse resp = service.normalizeIngredients(req);
+
+        assertThat(resp.getNormalizations()).isEmpty();
+    }
+
+    @Test
+    void normalizeIngredients_emptyIngredients_returnsEmpty() {
+        IngredientNormalizationService service = new IngredientNormalizationService(
+            WebClient.builder(), new GeminiApiKeyResolver(), new com.fasterxml.jackson.databind.ObjectMapper());
+        IngredientNormalizationRequest req = new IngredientNormalizationRequest();
+        req.setIngredients(List.of());
+
+        IngredientNormalizationResponse resp = service.normalizeIngredients(req);
+
+        assertThat(resp.getNormalizations()).isEmpty();
+    }
+
+    @Test
+    void normalizeIngredients_nullIngredients_returnsEmpty() {
+        IngredientNormalizationService service = new IngredientNormalizationService(
+            WebClient.builder(), new GeminiApiKeyResolver(), new com.fasterxml.jackson.databind.ObjectMapper());
+        IngredientNormalizationRequest req = new IngredientNormalizationRequest();
+        req.setIngredients(null);
+
+        IngredientNormalizationResponse resp = service.normalizeIngredients(req);
+
+        assertThat(resp.getNormalizations()).isEmpty();
+    }
+
+    @Test
+    void normalizeIngredients_multipleAmbiguous_returnsAllAboveThreshold() {
+        String stubJson = """
+            {"normalizations":[
+              {"index":0,"original":"some salt","normalized":"1/4 tsp fine sea salt","reason":"quantity unspecified","confidence":0.85},
+              {"index":2,"original":"a bit of olive oil","normalized":"1 tbsp olive oil","reason":"vague quantity","confidence":0.75}
+            ]}
+            """;
+        StubIngredientNormalizationService service = new StubIngredientNormalizationService(stubJson);
+        IngredientNormalizationRequest req = new IngredientNormalizationRequest();
+        req.setIngredients(List.of("some salt", "2 eggs", "a bit of olive oil"));
+
+        IngredientNormalizationResponse resp = service.normalizeIngredients(req);
+
+        assertThat(resp.getNormalizations()).hasSize(2);
+        assertThat(resp.getNormalizations().get(0).getIndex()).isZero();
+        assertThat(resp.getNormalizations().get(1).getIndex()).isEqualTo(2);
+    }
+}


### PR DESCRIPTION
## Problem
Closes part of #28 (backend slice). Ingredient lines entered by users can be ambiguous (e.g. 'some salt', 'a handful of flour') making recipes hard to reproduce.

## Scope
- POST `/api/recipes/normalize-ingredients` endpoint
- Gemini-backed `IngredientNormalizationService` with confidence filtering (>= 0.6)
- Request/Response/Model DTOs

## Out of scope
- Frontend ingredient normalization UI (separate PR in recipe-management-frontend)
- Issue #30 (Nutrition Estimate) — depends on this

## BDD Scenarios
**Scenario 1: Happy path**
- Given a recipe with ambiguous ingredient lines (e.g. 'some salt')
- When POST /api/recipes/normalize-ingredients is called
- Then 200 OK with normalization suggestions including normalized text and confidence

**Scenario 2: Low confidence filtered out**
- Given Gemini returns a suggestion with confidence < 0.6
- When the response is parsed
- Then the low-confidence suggestion is excluded from the response

**Scenario 3: Empty ingredient list**
- Given an empty ingredients array in the request
- When POST /api/recipes/normalize-ingredients is called
- Then 200 OK with empty normalizations list (graceful)

**Scenario 4: Service failure**
- Given the Gemini API throws an exception
- When POST /api/recipes/normalize-ingredients is called
- Then 200 OK with empty normalizations list (graceful degradation)

**Scenario 5: Regression — existing endpoints unaffected**
- Given existing /suggest-fields and /refine-instructions endpoints
- When the new service is wired into RecipeController
- Then all existing endpoint tests continue to pass

## Test Evidence
- `NormalizeIngredientsControllerTest`: 3 controller-level BDD tests
- `IngredientNormalizationServiceTest`: 5 service-level unit tests
- All existing controller tests updated for 4-arg constructor

## Acceptance Criteria
- [x] POST /normalize-ingredients returns normalized suggestions for ambiguous ingredients
- [x] Suggestions below confidence threshold are filtered out
- [x] Graceful degradation on empty list or API failure
- [x] All existing tests continue to pass