### PR TITLE
feat: add POST /api/recipes/estimate-nutrition endpoint (#30)

### DIFF
--- a/src/main/java/com/recipe/ai/controller/RecipeController.java
+++ b/src/main/java/com/recipe/ai/controller/RecipeController.java
@@ -6,9 +6,12 @@ import com.recipe.ai.model.IngredientNormalizationRequest;
 import com.recipe.ai.model.IngredientNormalizationResponse;
 import com.recipe.ai.model.InstructionRefinementRequest;
 import com.recipe.ai.model.InstructionRefinementResponse;
+import com.recipe.ai.model.NutritionEstimateRequest;
+import com.recipe.ai.model.NutritionEstimateResponse;
 import com.recipe.ai.service.FieldSuggestionService;
 import com.recipe.ai.service.IngredientNormalizationService;
 import com.recipe.ai.service.InstructionRefinementService;
+import com.recipe.ai.service.NutritionEstimateService;
 import com.recipe.ai.service.RecipeService;
 import com.recipe.ai.service.AISuggestionValidationException;
 import com.recipe.shared.model.Recipe;
@@ -35,16 +38,19 @@ public class RecipeController {
     private final FieldSuggestionService fieldSuggestionService;
     private final InstructionRefinementService instructionRefinementService;
     private final IngredientNormalizationService ingredientNormalizationService;
+    private final NutritionEstimateService nutritionEstimateService;
     private static final Logger log = LoggerFactory.getLogger(RecipeController.class);
 
     public RecipeController(RecipeService recipeService,
                             FieldSuggestionService fieldSuggestionService,
                             InstructionRefinementService instructionRefinementService,
-                            IngredientNormalizationService ingredientNormalizationService) {
+                            IngredientNormalizationService ingredientNormalizationService,
+                            NutritionEstimateService nutritionEstimateService) {
         this.recipeService = recipeService;
         this.fieldSuggestionService = fieldSuggestionService;
         this.instructionRefinementService = instructionRefinementService;
         this.ingredientNormalizationService = ingredientNormalizationService;
+        this.nutritionEstimateService = nutritionEstimateService;
     }
 
     @PostMapping("/generate")
@@ -140,6 +146,25 @@ public class RecipeController {
         } catch (Exception e) {
             log.error("Error in normalize-ingredients: {}", e.getMessage(), e);
             return new ResponseEntity<>(new IngredientNormalizationResponse(List.of()), HttpStatus.OK);
+        }
+    }
+
+    /**
+     * POST /api/recipes/estimate-nutrition
+     * Estimates nutritional values for a recipe based on its ingredients.
+     */
+    @PostMapping("/estimate-nutrition")
+    public ResponseEntity<NutritionEstimateResponse> estimateNutrition(
+            @RequestBody NutritionEstimateRequest request) {
+        try {
+            long start = System.currentTimeMillis();
+            NutritionEstimateResponse response = nutritionEstimateService.estimateNutrition(request);
+            long latencyMs = System.currentTimeMillis() - start;
+            log.info("estimate-nutrition: completed in {}ms", latencyMs);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("Error in estimate-nutrition: {}", e.getMessage(), e);
+            return ResponseEntity.ok(new NutritionEstimateResponse(null, null));
         }
     }
 }

--- a/src/main/java/com/recipe/ai/model/NutrientValue.java
+++ b/src/main/java/com/recipe/ai/model/NutrientValue.java
@@ -1,0 +1,28 @@
+package com.recipe.ai.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A single nutrient measurement, optionally estimated by AI.
+ */
+public class NutrientValue {
+
+    private final double value;
+    private final String unit;
+    private final boolean estimated;
+
+    @JsonCreator
+    public NutrientValue(
+            @JsonProperty("value") double value,
+            @JsonProperty("unit") String unit,
+            @JsonProperty("estimated") boolean estimated) {
+        this.value = value;
+        this.unit = unit;
+        this.estimated = estimated;
+    }
+
+    public double getValue() { return value; }
+    public String getUnit() { return unit; }
+    public boolean isEstimated() { return estimated; }
+}

--- a/src/main/java/com/recipe/ai/model/NutritionEstimate.java
+++ b/src/main/java/com/recipe/ai/model/NutritionEstimate.java
@@ -1,0 +1,46 @@
+package com.recipe.ai.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Nutrition estimate (per-serving or whole-recipe).
+ */
+public class NutritionEstimate {
+
+    private final NutrientValue calories;
+    private final NutrientValue protein;
+    private final NutrientValue carbs;
+    private final NutrientValue fat;
+    private final NutrientValue fiber;
+    private final List<String> warnings;
+    private final boolean isPartial;
+
+    @JsonCreator
+    public NutritionEstimate(
+            @JsonProperty("calories") NutrientValue calories,
+            @JsonProperty("protein") NutrientValue protein,
+            @JsonProperty("carbs") NutrientValue carbs,
+            @JsonProperty("fat") NutrientValue fat,
+            @JsonProperty("fiber") NutrientValue fiber,
+            @JsonProperty("warnings") List<String> warnings,
+            @JsonProperty("isPartial") boolean isPartial) {
+        this.calories = calories;
+        this.protein = protein;
+        this.carbs = carbs;
+        this.fat = fat;
+        this.fiber = fiber;
+        this.warnings = warnings == null ? List.of() : Collections.unmodifiableList(warnings);
+        this.isPartial = isPartial;
+    }
+
+    public NutrientValue getCalories() { return calories; }
+    public NutrientValue getProtein() { return protein; }
+    public NutrientValue getCarbs() { return carbs; }
+    public NutrientValue getFat() { return fat; }
+    public NutrientValue getFiber() { return fiber; }
+    public List<String> getWarnings() { return warnings; }
+    public boolean isPartial() { return isPartial; }
+}

--- a/src/main/java/com/recipe/ai/model/NutritionEstimateRequest.java
+++ b/src/main/java/com/recipe/ai/model/NutritionEstimateRequest.java
@@ -1,0 +1,27 @@
+package com.recipe.ai.model;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Request DTO for POST /api/recipes/estimate-nutrition.
+ */
+public class NutritionEstimateRequest {
+
+    private List<String> ingredients;
+    private int servings;
+    private String recipeName;
+
+    public NutritionEstimateRequest() {}
+
+    public List<String> getIngredients() {
+        return ingredients == null ? null : Collections.unmodifiableList(ingredients);
+    }
+    public void setIngredients(List<String> ingredients) { this.ingredients = ingredients; }
+
+    public int getServings() { return servings; }
+    public void setServings(int servings) { this.servings = servings; }
+
+    public String getRecipeName() { return recipeName; }
+    public void setRecipeName(String recipeName) { this.recipeName = recipeName; }
+}

--- a/src/main/java/com/recipe/ai/model/NutritionEstimateResponse.java
+++ b/src/main/java/com/recipe/ai/model/NutritionEstimateResponse.java
@@ -1,0 +1,24 @@
+package com.recipe.ai.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Response DTO for POST /api/recipes/estimate-nutrition.
+ */
+public class NutritionEstimateResponse {
+
+    private final NutritionEstimate perServing;
+    private final NutritionEstimate wholeRecipe;
+
+    @JsonCreator
+    public NutritionEstimateResponse(
+            @JsonProperty("perServing") NutritionEstimate perServing,
+            @JsonProperty("wholeRecipe") NutritionEstimate wholeRecipe) {
+        this.perServing = perServing;
+        this.wholeRecipe = wholeRecipe;
+    }
+
+    public NutritionEstimate getPerServing() { return perServing; }
+    public NutritionEstimate getWholeRecipe() { return wholeRecipe; }
+}

--- a/src/main/java/com/recipe/ai/service/NutritionEstimateService.java
+++ b/src/main/java/com/recipe/ai/service/NutritionEstimateService.java
@@ -1,0 +1,216 @@
+package com.recipe.ai.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.recipe.ai.model.NutrientValue;
+import com.recipe.ai.model.NutritionEstimate;
+import com.recipe.ai.model.NutritionEstimateRequest;
+import com.recipe.ai.model.NutritionEstimateResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service that calls Gemini to estimate nutritional values for a recipe.
+ *
+ * BDD Scenarios:
+ *   Scenario 1: All ingredients known → full estimate returned
+ *   Scenario 2: Some ingredients unknown → partial estimate with warnings
+ *   Scenario 3: Empty ingredient list → returns empty response (graceful)
+ *   Scenario 4: API failure → returns empty response (graceful degradation)
+ */
+@Service
+public class NutritionEstimateService {
+
+    private static final Logger log = LoggerFactory.getLogger(NutritionEstimateService.class);
+    private static final String API_KEY_HEADER = "x-goog-api-key";
+
+    @Value("${gemini.api.url:https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent}")
+    private String geminiApiUrl;
+
+    private final WebClient.Builder webClientBuilder;
+    private final GeminiApiKeyResolver apiKeyResolver;
+    private final ObjectMapper objectMapper;
+
+    public NutritionEstimateService(WebClient.Builder webClientBuilder,
+                                    GeminiApiKeyResolver apiKeyResolver,
+                                    ObjectMapper objectMapper) {
+        this.webClientBuilder = webClientBuilder;
+        this.apiKeyResolver = apiKeyResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Estimates nutrition for the given recipe ingredients.
+     * Returns empty response on any error (graceful degradation).
+     */
+    public NutritionEstimateResponse estimateNutrition(NutritionEstimateRequest request) {
+        List<String> ingredients = request.getIngredients();
+        if (ingredients == null || ingredients.isEmpty()) {
+            return new NutritionEstimateResponse(null, null);
+        }
+
+        if (!apiKeyResolver.hasValidApiKey()) {
+            log.warn("No valid Gemini API key — skipping nutrition estimation.");
+            return new NutritionEstimateResponse(null, null);
+        }
+
+        String effectiveApiKey = apiKeyResolver.resolveEffectiveApiKey();
+        int servings = request.getServings() > 0 ? request.getServings() : 1;
+        String prompt = buildPrompt(ingredients, servings, request.getRecipeName());
+        String jsonSchema = buildResponseSchema();
+
+        Map<String, Object> payload = Map.of(
+            "contents", List.of(Map.of("parts", List.of(Map.of("text", prompt)))),
+            "generationConfig", Map.of(
+                "responseMimeType", "application/json",
+                "responseSchema", parseSchema(jsonSchema)
+            )
+        );
+
+        try {
+            WebClient client = webClientBuilder
+                .baseUrl(geminiApiUrl)
+                .defaultHeader(API_KEY_HEADER, effectiveApiKey)
+                .build();
+
+            String responseBody = client.post()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromValue(payload))
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+            return parseGeminiResponse(responseBody);
+        } catch (Exception e) {
+            log.error("Nutrition estimation call to Gemini failed: {}", e.getMessage(), e);
+            return new NutritionEstimateResponse(null, null);
+        }
+    }
+
+    String buildPrompt(List<String> ingredients, int servings, String recipeName) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("You are a nutritionist. Estimate the nutritional values for a recipe");
+        if (recipeName != null && !recipeName.isBlank()) {
+            sb.append(" named \"").append(recipeName).append("\"");
+        }
+        sb.append(".\n\n");
+        sb.append("Ingredients:\n");
+        for (String ingredient : ingredients) {
+            sb.append("- ").append(ingredient).append("\n");
+        }
+        sb.append("\nServings: ").append(servings).append("\n\n");
+        sb.append("Provide estimates for the WHOLE recipe and PER SERVING (whole/servings).\n");
+        sb.append("For each nutrient (calories, protein, carbs, fat, fiber), provide:\n");
+        sb.append("- value: numeric amount\n");
+        sb.append("- unit: the unit string (e.g. 'kcal', 'g')\n");
+        sb.append("- estimated: true if you had to estimate due to ambiguity or unknown ingredient\n\n");
+        sb.append("Include a 'warnings' array listing any ingredients that were unknown or ambiguous.\n");
+        sb.append("Set 'isPartial' to true if any ingredient could not be estimated.\n");
+        return sb.toString();
+    }
+
+    String buildResponseSchema() {
+        return """
+            {
+              "type": "object",
+              "properties": {
+                "perServing": {
+                  "type": "object",
+                  "properties": {
+                    "calories": { "type": "object", "properties": { "value": { "type": "number" }, "unit": { "type": "string" }, "estimated": { "type": "boolean" } }, "required": ["value", "unit", "estimated"] },
+                    "protein":  { "type": "object", "properties": { "value": { "type": "number" }, "unit": { "type": "string" }, "estimated": { "type": "boolean" } }, "required": ["value", "unit", "estimated"] },
+                    "carbs":    { "type": "object", "properties": { "value": { "type": "number" }, "unit": { "type": "string" }, "estimated": { "type": "boolean" } }, "required": ["value", "unit", "estimated"] },
+                    "fat":      { "type": "object", "properties": { "value": { "type": "number" }, "unit": { "type": "string" }, "estimated": { "type": "boolean" } }, "required": ["value", "unit", "estimated"] },
+                    "fiber":    { "type": "object", "properties": { "value": { "type": "number" }, "unit": { "type": "string" }, "estimated": { "type": "boolean" } }, "required": ["value", "unit", "estimated"] },
+                    "warnings": { "type": "array", "items": { "type": "string" } },
+                    "isPartial": { "type": "boolean" }
+                  },
+                  "required": ["calories", "protein", "carbs", "fat", "fiber", "warnings", "isPartial"]
+                },
+                "wholeRecipe": {
+                  "type": "object",
+                  "properties": {
+                    "calories": { "type": "object", "properties": { "value": { "type": "number" }, "unit": { "type": "string" }, "estimated": { "type": "boolean" } }, "required": ["value", "unit", "estimated"] },
+                    "protein":  { "type": "object", "properties": { "value": { "type": "number" }, "unit": { "type": "string" }, "estimated": { "type": "boolean" } }, "required": ["value", "unit", "estimated"] },
+                    "carbs":    { "type": "object", "properties": { "value": { "type": "number" }, "unit": { "type": "string" }, "estimated": { "type": "boolean" } }, "required": ["value", "unit", "estimated"] },
+                    "fat":      { "type": "object", "properties": { "value": { "type": "number" }, "unit": { "type": "string" }, "estimated": { "type": "boolean" } }, "required": ["value", "unit", "estimated"] },
+                    "fiber":    { "type": "object", "properties": { "value": { "type": "number" }, "unit": { "type": "string" }, "estimated": { "type": "boolean" } }, "required": ["value", "unit", "estimated"] },
+                    "warnings": { "type": "array", "items": { "type": "string" } },
+                    "isPartial": { "type": "boolean" }
+                  },
+                  "required": ["calories", "protein", "carbs", "fat", "fiber", "warnings", "isPartial"]
+                }
+              },
+              "required": ["perServing", "wholeRecipe"]
+            }
+            """;
+    }
+
+    NutritionEstimateResponse parseGeminiResponse(String body) {
+        try {
+            JsonNode root = objectMapper.readTree(body);
+            JsonNode candidates = root.path("candidates");
+            if (!candidates.isArray() || candidates.isEmpty()) {
+                log.warn("estimateNutrition: no candidates in Gemini response");
+                return new NutritionEstimateResponse(null, null);
+            }
+            String text = candidates.get(0).path("content").path("parts").get(0).path("text").asText();
+            JsonNode parsed = objectMapper.readTree(text);
+
+            NutritionEstimate perServing = parseEstimate(parsed.path("perServing"));
+            NutritionEstimate wholeRecipe = parseEstimate(parsed.path("wholeRecipe"));
+            return new NutritionEstimateResponse(perServing, wholeRecipe);
+        } catch (Exception e) {
+            log.error("Failed to parse nutrition estimation response: {}", e.getMessage(), e);
+            return new NutritionEstimateResponse(null, null);
+        }
+    }
+
+    private NutritionEstimate parseEstimate(JsonNode node) {
+        if (node == null || node.isMissingNode()) return null;
+
+        NutrientValue calories = parseNutrient(node.path("calories"));
+        NutrientValue protein  = parseNutrient(node.path("protein"));
+        NutrientValue carbs    = parseNutrient(node.path("carbs"));
+        NutrientValue fat      = parseNutrient(node.path("fat"));
+        NutrientValue fiber    = parseNutrient(node.path("fiber"));
+
+        List<String> warnings = new ArrayList<>();
+        JsonNode warningsNode = node.path("warnings");
+        if (warningsNode.isArray()) {
+            for (JsonNode w : warningsNode) {
+                warnings.add(w.asText());
+            }
+        }
+        boolean isPartial = node.path("isPartial").asBoolean(false);
+
+        return new NutritionEstimate(calories, protein, carbs, fat, fiber, warnings, isPartial);
+    }
+
+    private NutrientValue parseNutrient(JsonNode node) {
+        if (node == null || node.isMissingNode()) return null;
+        double value = node.path("value").asDouble(0.0);
+        String unit = node.path("unit").asText("g");
+        boolean estimated = node.path("estimated").asBoolean(false);
+        return new NutrientValue(value, unit, estimated);
+    }
+
+    private Map<String, Object> parseSchema(String jsonSchema) {
+        try {
+            return objectMapper.readValue(jsonSchema, new TypeReference<Map<String, Object>>() {});
+        } catch (Exception e) {
+            log.warn("Failed to parse nutrition estimate schema: {}", e.getMessage());
+            return Map.of();
+        }
+    }
+}

--- a/src/test/java/com/recipe/ai/controller/EstimateNutritionControllerTest.java
+++ b/src/test/java/com/recipe/ai/controller/EstimateNutritionControllerTest.java
@@ -1,0 +1,174 @@
+package com.recipe.ai.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.recipe.ai.model.FieldSuggestionRequest;
+import com.recipe.ai.model.FieldSuggestionsResponse;
+import com.recipe.ai.model.IngredientNormalizationRequest;
+import com.recipe.ai.model.IngredientNormalizationResponse;
+import com.recipe.ai.model.InstructionRefinementRequest;
+import com.recipe.ai.model.InstructionRefinementResponse;
+import com.recipe.ai.model.NutrientValue;
+import com.recipe.ai.model.NutritionEstimate;
+import com.recipe.ai.model.NutritionEstimateRequest;
+import com.recipe.ai.model.NutritionEstimateResponse;
+import com.recipe.ai.service.AISuggestionValidator;
+import com.recipe.ai.service.FieldSuggestionService;
+import com.recipe.ai.service.GeminiApiKeyResolver;
+import com.recipe.ai.service.IngredientNormalizationService;
+import com.recipe.ai.service.InstructionRefinementService;
+import com.recipe.ai.service.NutritionEstimateService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * BDD controller tests for POST /api/recipes/estimate-nutrition
+ */
+class EstimateNutritionControllerTest {
+
+    private RecipeController controller;
+
+    static class StubNutritionEstimateService extends NutritionEstimateService {
+        private final NutritionEstimateResponse stubResponse;
+        StubNutritionEstimateService(NutritionEstimateResponse stubResponse) {
+            super(WebClient.builder(), new GeminiApiKeyResolver(), new ObjectMapper());
+            this.stubResponse = stubResponse;
+        }
+        @Override
+        public NutritionEstimateResponse estimateNutrition(NutritionEstimateRequest request) {
+            return stubResponse;
+        }
+    }
+
+    static class ThrowingNutritionEstimateService extends NutritionEstimateService {
+        ThrowingNutritionEstimateService() {
+            super(WebClient.builder(), new GeminiApiKeyResolver(), new ObjectMapper());
+        }
+        @Override
+        public NutritionEstimateResponse estimateNutrition(NutritionEstimateRequest request) {
+            throw new RuntimeException("Simulated Gemini failure");
+        }
+    }
+
+    static class NoOpRecipeService extends com.recipe.ai.service.RecipeService {
+        NoOpRecipeService() {
+            super(WebClient.builder(), new ObjectMapper(), new AISuggestionValidator());
+        }
+    }
+
+    static class NoOpFieldSuggestionService extends FieldSuggestionService {
+        NoOpFieldSuggestionService() {
+            super(WebClient.builder(), new GeminiApiKeyResolver(), new ObjectMapper());
+        }
+        @Override
+        public FieldSuggestionsResponse suggestFields(FieldSuggestionRequest request) {
+            return new FieldSuggestionsResponse(List.of());
+        }
+    }
+
+    static class NoOpInstructionRefinementService extends InstructionRefinementService {
+        NoOpInstructionRefinementService() {
+            super(WebClient.builder(), new GeminiApiKeyResolver(), new ObjectMapper());
+        }
+        @Override
+        public InstructionRefinementResponse refineInstructions(InstructionRefinementRequest request) {
+            return new InstructionRefinementResponse(List.of());
+        }
+    }
+
+    static class NoOpIngredientNormalizationService extends IngredientNormalizationService {
+        NoOpIngredientNormalizationService() {
+            super(WebClient.builder(), new GeminiApiKeyResolver(), new ObjectMapper());
+        }
+        @Override
+        public IngredientNormalizationResponse normalizeIngredients(IngredientNormalizationRequest request) {
+            return new IngredientNormalizationResponse(List.of());
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        NutrientValue cal = new NutrientValue(350, "kcal", false);
+        NutrientValue prot = new NutrientValue(12, "g", false);
+        NutrientValue carb = new NutrientValue(45, "g", false);
+        NutrientValue fat = new NutrientValue(10, "g", false);
+        NutrientValue fiber = new NutrientValue(4, "g", false);
+        NutritionEstimate perServing = new NutritionEstimate(cal, prot, carb, fat, fiber, List.of(), false);
+        NutritionEstimate wholeRecipe = new NutritionEstimate(
+            new NutrientValue(700, "kcal", false),
+            new NutrientValue(24, "g", false),
+            new NutrientValue(90, "g", false),
+            new NutrientValue(20, "g", false),
+            new NutrientValue(8, "g", false),
+            List.of(), false);
+        NutritionEstimateResponse stubResp = new NutritionEstimateResponse(perServing, wholeRecipe);
+
+        controller = new RecipeController(
+            new NoOpRecipeService(),
+            new NoOpFieldSuggestionService(),
+            new NoOpInstructionRefinementService(),
+            new NoOpIngredientNormalizationService(),
+            new StubNutritionEstimateService(stubResp)
+        );
+    }
+
+    @Test
+    void estimateNutrition_validIngredients_returnsBothEstimates() {
+        NutritionEstimateRequest req = new NutritionEstimateRequest();
+        req.setIngredients(List.of("2 cups flour", "1 cup sugar", "2 eggs"));
+        req.setServings(2);
+        req.setRecipeName("Cake");
+
+        ResponseEntity<NutritionEstimateResponse> resp = controller.estimateNutrition(req);
+
+        assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(resp.getBody()).isNotNull();
+        assertThat(resp.getBody().getPerServing()).isNotNull();
+        assertThat(resp.getBody().getWholeRecipe()).isNotNull();
+        assertThat(resp.getBody().getPerServing().getCalories().getValue()).isEqualTo(350.0);
+        assertThat(resp.getBody().getWholeRecipe().getCalories().getValue()).isEqualTo(700.0);
+    }
+
+    @Test
+    void estimateNutrition_emptyIngredients_returnsNullEstimates() {
+        RecipeController ctrl = new RecipeController(
+            new NoOpRecipeService(),
+            new NoOpFieldSuggestionService(),
+            new NoOpInstructionRefinementService(),
+            new NoOpIngredientNormalizationService(),
+            new StubNutritionEstimateService(new NutritionEstimateResponse(null, null))
+        );
+        NutritionEstimateRequest req = new NutritionEstimateRequest();
+        req.setIngredients(List.of());
+
+        ResponseEntity<NutritionEstimateResponse> resp = ctrl.estimateNutrition(req);
+
+        assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(resp.getBody().getPerServing()).isNull();
+        assertThat(resp.getBody().getWholeRecipe()).isNull();
+    }
+
+    @Test
+    void estimateNutrition_serviceThrows_returnsOkWithNullEstimates() {
+        RecipeController ctrl = new RecipeController(
+            new NoOpRecipeService(),
+            new NoOpFieldSuggestionService(),
+            new NoOpInstructionRefinementService(),
+            new NoOpIngredientNormalizationService(),
+            new ThrowingNutritionEstimateService()
+        );
+        NutritionEstimateRequest req = new NutritionEstimateRequest();
+        req.setIngredients(List.of("2 cups flour"));
+
+        ResponseEntity<NutritionEstimateResponse> resp = ctrl.estimateNutrition(req);
+
+        assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(resp.getBody().getPerServing()).isNull();
+        assertThat(resp.getBody().getWholeRecipe()).isNull();
+    }
+}

--- a/src/test/java/com/recipe/ai/controller/NormalizeIngredientsControllerTest.java
+++ b/src/test/java/com/recipe/ai/controller/NormalizeIngredientsControllerTest.java
@@ -11,7 +11,10 @@ import com.recipe.ai.service.FieldSuggestionService;
 import com.recipe.ai.service.GeminiApiKeyResolver;
 import com.recipe.ai.service.IngredientNormalizationService;
 import com.recipe.ai.service.InstructionRefinementService;
+import com.recipe.ai.service.NutritionEstimateService;
 import com.recipe.ai.service.AISuggestionValidator;
+import com.recipe.ai.model.NutritionEstimateRequest;
+import com.recipe.ai.model.NutritionEstimateResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -92,6 +95,16 @@ class NormalizeIngredientsControllerTest {
         }
     }
 
+    static class NoOpNutritionEstimateService extends NutritionEstimateService {
+        NoOpNutritionEstimateService() {
+            super(WebClient.builder(), new GeminiApiKeyResolver(), new ObjectMapper());
+        }
+        @Override
+        public NutritionEstimateResponse estimateNutrition(NutritionEstimateRequest request) {
+            return new NutritionEstimateResponse(null, null);
+        }
+    }
+
     @BeforeEach
     void setUp() {
         IngredientNormalizationResponse stubResp = new IngredientNormalizationResponse(List.of(
@@ -101,7 +114,8 @@ class NormalizeIngredientsControllerTest {
             new NoOpRecipeService(),
             new NoOpFieldSuggestionService(),
             new NoOpInstructionRefinementService(),
-            new StubIngredientNormalizationService(stubResp)
+            new StubIngredientNormalizationService(stubResp),
+            new NoOpNutritionEstimateService()
         );
     }
 
@@ -127,7 +141,8 @@ class NormalizeIngredientsControllerTest {
             new NoOpRecipeService(),
             new NoOpFieldSuggestionService(),
             new NoOpInstructionRefinementService(),
-            new StubIngredientNormalizationService(new IngredientNormalizationResponse(List.of()))
+            new StubIngredientNormalizationService(new IngredientNormalizationResponse(List.of())),
+            new NoOpNutritionEstimateService()
         );
         IngredientNormalizationRequest req = new IngredientNormalizationRequest();
         req.setIngredients(List.of());
@@ -144,7 +159,8 @@ class NormalizeIngredientsControllerTest {
             new NoOpRecipeService(),
             new NoOpFieldSuggestionService(),
             new NoOpInstructionRefinementService(),
-            new ThrowingIngredientNormalizationService()
+            new ThrowingIngredientNormalizationService(),
+            new NoOpNutritionEstimateService()
         );
         IngredientNormalizationRequest req = new IngredientNormalizationRequest();
         req.setIngredients(List.of("some ingredient"));

--- a/src/test/java/com/recipe/ai/controller/RecipeControllerTest.java
+++ b/src/test/java/com/recipe/ai/controller/RecipeControllerTest.java
@@ -3,8 +3,11 @@ package com.recipe.ai.controller;
 import com.recipe.ai.service.RecipeService;
 import com.recipe.ai.service.InstructionRefinementService;
 import com.recipe.ai.service.IngredientNormalizationService;
+import com.recipe.ai.service.NutritionEstimateService;
 import com.recipe.ai.model.IngredientNormalizationRequest;
 import com.recipe.ai.model.IngredientNormalizationResponse;
+import com.recipe.ai.model.NutritionEstimateRequest;
+import com.recipe.ai.model.NutritionEstimateResponse;
 import com.recipe.ai.service.FieldSuggestionService;
 import com.recipe.ai.model.InstructionRefinementRequest;
 import com.recipe.ai.model.InstructionRefinementResponse;
@@ -91,13 +94,24 @@ public class RecipeControllerTest {
         }
     }
 
+    static class NoOpNutritionEstimateService extends NutritionEstimateService {
+        public NoOpNutritionEstimateService() {
+            super(WebClient.builder(), new com.recipe.ai.service.GeminiApiKeyResolver(), new com.fasterxml.jackson.databind.ObjectMapper());
+        }
+        @Override
+        public NutritionEstimateResponse estimateNutrition(NutritionEstimateRequest request) {
+            return new NutritionEstimateResponse(null, null);
+        }
+    }
+
     @BeforeEach
     void setup() {
         this.controller = new RecipeController(
             new TestRecipeService(),
             new TestFieldSuggestionService(),
             new TestInstructionRefinementService(),
-            new NoOpIngredientNormalizationService()
+            new NoOpIngredientNormalizationService(),
+            new NoOpNutritionEstimateService()
         );
     }
 

--- a/src/test/java/com/recipe/ai/controller/RefineInstructionsControllerTest.java
+++ b/src/test/java/com/recipe/ai/controller/RefineInstructionsControllerTest.java
@@ -11,6 +11,9 @@ import com.recipe.ai.service.GeminiApiKeyResolver;
 import com.recipe.ai.service.AISuggestionValidator;
 import com.recipe.ai.service.RecipeService;
 import com.recipe.ai.service.IngredientNormalizationService;
+import com.recipe.ai.service.NutritionEstimateService;
+import com.recipe.ai.model.NutritionEstimateRequest;
+import com.recipe.ai.model.NutritionEstimateResponse;
 import com.recipe.ai.model.IngredientNormalizationRequest;
 import com.recipe.ai.model.IngredientNormalizationResponse;
 import com.recipe.ai.model.Units;
@@ -94,6 +97,16 @@ class RefineInstructionsControllerTest {
         }
     }
 
+    static class NoOpNutritionEstimateService extends NutritionEstimateService {
+        NoOpNutritionEstimateService() {
+            super(WebClient.builder(), new GeminiApiKeyResolver(), new ObjectMapper());
+        }
+        @Override
+        public NutritionEstimateResponse estimateNutrition(NutritionEstimateRequest request) {
+            return new NutritionEstimateResponse(null, null);
+        }
+    }
+
     @BeforeEach
     void setUp() {
         InstructionRefinementResponse stubResp = new InstructionRefinementResponse(List.of(
@@ -103,7 +116,8 @@ class RefineInstructionsControllerTest {
             new NoOpRecipeService(),
             new NoOpFieldSuggestionService(),
             new StubInstructionRefinementService(stubResp),
-            new NoOpIngredientNormalizationService()
+            new NoOpIngredientNormalizationService(),
+            new NoOpNutritionEstimateService()
         );
     }
 
@@ -127,7 +141,8 @@ class RefineInstructionsControllerTest {
             new NoOpRecipeService(),
             new NoOpFieldSuggestionService(),
             new StubInstructionRefinementService(new InstructionRefinementResponse(List.of())),
-            new NoOpIngredientNormalizationService()
+            new NoOpIngredientNormalizationService(),
+            new NoOpNutritionEstimateService()
         );
         InstructionRefinementRequest req = new InstructionRefinementRequest();
         req.setInstructions(List.of("Preheat oven to 375°F."));
@@ -142,7 +157,8 @@ class RefineInstructionsControllerTest {
             new NoOpRecipeService(),
             new NoOpFieldSuggestionService(),
             new ThrowingInstructionRefinementService(),
-            new NoOpIngredientNormalizationService()
+            new NoOpIngredientNormalizationService(),
+            new NoOpNutritionEstimateService()
         );
         InstructionRefinementRequest req = new InstructionRefinementRequest();
         req.setInstructions(List.of("some step"));

--- a/src/test/java/com/recipe/ai/controller/SuggestFieldsControllerTest.java
+++ b/src/test/java/com/recipe/ai/controller/SuggestFieldsControllerTest.java
@@ -10,8 +10,11 @@ import com.recipe.ai.service.IngredientNormalizationService;
 import com.recipe.ai.model.IngredientNormalizationRequest;
 import com.recipe.ai.model.IngredientNormalizationResponse;
 import com.recipe.ai.service.InstructionRefinementService;
+import com.recipe.ai.service.NutritionEstimateService;
 import com.recipe.ai.service.GeminiApiKeyResolver;
 import com.recipe.ai.service.AISuggestionValidator;
+import com.recipe.ai.model.NutritionEstimateRequest;
+import com.recipe.ai.model.NutritionEstimateResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
@@ -65,6 +68,16 @@ class SuggestFieldsControllerTest {
         }
     }
 
+    static class NoOpNutritionEstimateService extends NutritionEstimateService {
+        NoOpNutritionEstimateService() {
+            super(WebClient.builder(), new GeminiApiKeyResolver(), new ObjectMapper());
+        }
+        @Override
+        public NutritionEstimateResponse estimateNutrition(NutritionEstimateRequest request) {
+            return new NutritionEstimateResponse(null, null);
+        }
+    }
+
     @BeforeEach
     void setUp() {
         FieldSuggestionsResponse stubResp = new FieldSuggestionsResponse(List.of(
@@ -74,7 +87,8 @@ class SuggestFieldsControllerTest {
             new NoOpRecipeService(),
             new StubFieldSuggestionService(stubResp),
             new NoOpInstructionRefinementService(),
-            new NoOpIngredientNormalizationService()
+            new NoOpIngredientNormalizationService(),
+            new NoOpNutritionEstimateService()
         );
     }
 
@@ -98,7 +112,8 @@ class SuggestFieldsControllerTest {
             new NoOpRecipeService(),
             new StubFieldSuggestionService(empty),
             new NoOpInstructionRefinementService(),
-            new NoOpIngredientNormalizationService()
+            new NoOpIngredientNormalizationService(),
+            new NoOpNutritionEstimateService()
         );
 
         ResponseEntity<FieldSuggestionsResponse> resp = ctrl.suggestFields(new FieldSuggestionRequest());

--- a/src/test/java/com/recipe/ai/service/NutritionEstimateServiceTest.java
+++ b/src/test/java/com/recipe/ai/service/NutritionEstimateServiceTest.java
@@ -1,0 +1,151 @@
+package com.recipe.ai.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.recipe.ai.model.NutritionEstimateRequest;
+import com.recipe.ai.model.NutritionEstimateResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for NutritionEstimateService prompt building and response parsing.
+ *
+ * BDD Scenarios:
+ *   Scenario 1: All ingredients known → full estimate with no warnings
+ *   Scenario 2: Unknown ingredient → partial estimate with warning
+ *   Scenario 3: Empty ingredient list → returns empty response
+ *   Scenario 4: API error → graceful empty response
+ */
+class NutritionEstimateServiceTest {
+
+    static class StubNutritionEstimateService extends NutritionEstimateService {
+        private final String stubJson;
+
+        StubNutritionEstimateService(String stubJson) {
+            super(WebClient.builder(), new GeminiApiKeyResolver(), new ObjectMapper());
+            this.stubJson = stubJson;
+        }
+
+        @Override
+        public NutritionEstimateResponse estimateNutrition(NutritionEstimateRequest request) {
+            List<String> ingredients = request.getIngredients();
+            if (ingredients == null || ingredients.isEmpty()) {
+                return new NutritionEstimateResponse(null, null);
+            }
+            return parseGeminiResponse(buildFakeGeminiWrapper(stubJson));
+        }
+
+        private String buildFakeGeminiWrapper(String innerJson) {
+            return "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":" +
+                   new com.fasterxml.jackson.databind.ObjectMapper()
+                       .valueToTree(innerJson).toString() +
+                   "}]}}]}";
+        }
+    }
+
+    @Test
+    void estimateNutrition_happyPath_returnsBothEstimates() {
+        String innerJson = """
+            {
+              "perServing": {
+                "calories": {"value": 350, "unit": "kcal", "estimated": false},
+                "protein":  {"value": 12, "unit": "g", "estimated": false},
+                "carbs":    {"value": 45, "unit": "g", "estimated": false},
+                "fat":      {"value": 10, "unit": "g", "estimated": false},
+                "fiber":    {"value": 4, "unit": "g", "estimated": false},
+                "warnings": [],
+                "isPartial": false
+              },
+              "wholeRecipe": {
+                "calories": {"value": 700, "unit": "kcal", "estimated": false},
+                "protein":  {"value": 24, "unit": "g", "estimated": false},
+                "carbs":    {"value": 90, "unit": "g", "estimated": false},
+                "fat":      {"value": 20, "unit": "g", "estimated": false},
+                "fiber":    {"value": 8, "unit": "g", "estimated": false},
+                "warnings": [],
+                "isPartial": false
+              }
+            }
+            """;
+        StubNutritionEstimateService service = new StubNutritionEstimateService(innerJson);
+        NutritionEstimateRequest req = new NutritionEstimateRequest();
+        req.setIngredients(List.of("2 cups flour", "1 cup sugar"));
+        req.setServings(2);
+
+        NutritionEstimateResponse resp = service.estimateNutrition(req);
+
+        assertThat(resp.getPerServing()).isNotNull();
+        assertThat(resp.getWholeRecipe()).isNotNull();
+        assertThat(resp.getPerServing().getCalories().getValue()).isEqualTo(350.0);
+        assertThat(resp.getWholeRecipe().getCalories().getValue()).isEqualTo(700.0);
+        assertThat(resp.getPerServing().isPartial()).isFalse();
+        assertThat(resp.getPerServing().getWarnings()).isEmpty();
+    }
+
+    @Test
+    void estimateNutrition_unknownIngredient_returnsPartialWithWarning() {
+        String innerJson = """
+            {
+              "perServing": {
+                "calories": {"value": 200, "unit": "kcal", "estimated": true},
+                "protein":  {"value": 5, "unit": "g", "estimated": true},
+                "carbs":    {"value": 30, "unit": "g", "estimated": true},
+                "fat":      {"value": 8, "unit": "g", "estimated": true},
+                "fiber":    {"value": 2, "unit": "g", "estimated": true},
+                "warnings": ["Unknown ingredient: 'mystery powder'"],
+                "isPartial": true
+              },
+              "wholeRecipe": {
+                "calories": {"value": 400, "unit": "kcal", "estimated": true},
+                "protein":  {"value": 10, "unit": "g", "estimated": true},
+                "carbs":    {"value": 60, "unit": "g", "estimated": true},
+                "fat":      {"value": 16, "unit": "g", "estimated": true},
+                "fiber":    {"value": 4, "unit": "g", "estimated": true},
+                "warnings": ["Unknown ingredient: 'mystery powder'"],
+                "isPartial": true
+              }
+            }
+            """;
+        StubNutritionEstimateService service = new StubNutritionEstimateService(innerJson);
+        NutritionEstimateRequest req = new NutritionEstimateRequest();
+        req.setIngredients(List.of("1 cup flour", "2 tsp mystery powder"));
+        req.setServings(2);
+
+        NutritionEstimateResponse resp = service.estimateNutrition(req);
+
+        assertThat(resp.getPerServing()).isNotNull();
+        assertThat(resp.getPerServing().isPartial()).isTrue();
+        assertThat(resp.getPerServing().getWarnings()).hasSize(1);
+        assertThat(resp.getPerServing().getWarnings().get(0)).contains("mystery powder");
+        assertThat(resp.getPerServing().getCalories().isEstimated()).isTrue();
+    }
+
+    @Test
+    void estimateNutrition_emptyIngredients_returnsEmptyResponse() {
+        NutritionEstimateService service = new NutritionEstimateService(
+            WebClient.builder(), new GeminiApiKeyResolver(), new ObjectMapper());
+        NutritionEstimateRequest req = new NutritionEstimateRequest();
+        req.setIngredients(List.of());
+
+        NutritionEstimateResponse resp = service.estimateNutrition(req);
+
+        assertThat(resp.getPerServing()).isNull();
+        assertThat(resp.getWholeRecipe()).isNull();
+    }
+
+    @Test
+    void estimateNutrition_nullIngredients_returnsEmptyResponse() {
+        NutritionEstimateService service = new NutritionEstimateService(
+            WebClient.builder(), new GeminiApiKeyResolver(), new ObjectMapper());
+        NutritionEstimateRequest req = new NutritionEstimateRequest();
+        req.setIngredients(null);
+
+        NutritionEstimateResponse resp = service.estimateNutrition(req);
+
+        assertThat(resp.getPerServing()).isNull();
+        assertThat(resp.getWholeRecipe()).isNull();
+    }
+}


### PR DESCRIPTION
## Summary
Implements the backend nutrition estimation endpoint for issue #30.

## Changes
- **4 new DTOs**: `NutritionEstimateRequest`, `NutrientValue`, `NutritionEstimate`, `NutritionEstimateResponse`
- **New service**: `NutritionEstimateService` — calls Gemini to estimate per-serving + whole-recipe nutrition
- **Controller update**: 5-arg `RecipeController` constructor + `POST /api/recipes/estimate-nutrition`
- **Tests**: 2 new test files (7 BDD scenarios), all 4 existing controller tests updated for new constructor

## BDD Scenarios

**Scenario 1: All ingredients known → full estimate**
Given a recipe with 2 cups flour and 1 cup sugar
When POST /estimate-nutrition is called with servings=2
Then per-serving and whole-recipe estimates are returned with isPartial=false

**Scenario 2: Unknown ingredient → partial estimate with warnings**
Given a recipe that includes an unrecognized ingredient
When POST /estimate-nutrition is called
Then the response has isPartial=true and warnings list the problematic ingredients

**Scenario 3: Empty ingredient list → graceful empty response**
Given an empty ingredients array
When POST /estimate-nutrition is called
Then 200 OK with null perServing and wholeRecipe is returned

**Scenario 4: API failure → graceful fallback**
Given Gemini returns an error
When POST /estimate-nutrition is called
Then 200 OK with null estimates is returned (no hard failure)

Closes #30