### PR TITLE
CI: add deploy auth precheck before reusable CD

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,9 +21,71 @@ jobs:
       actions: write
       packages: read
 
+  deploy-auth-precheck:
+    name: Deploy Auth Precheck
+    needs: ci
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Validate deploy secrets format
+        env:
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${GCP_PROJECT_ID:-}" ]]; then
+            echo "::error::Missing required secret: GCP_PROJECT_ID"
+            exit 1
+          fi
+
+          if [[ -z "${GCP_SA_KEY:-}" ]]; then
+            echo "::error::Missing required secret: GCP_SA_KEY"
+            exit 1
+          fi
+
+          sa_file="$(mktemp)"
+          trap 'rm -f "$sa_file"' EXIT
+          printf '%s' "$GCP_SA_KEY" > "$sa_file"
+
+          python - "$sa_file" <<'PY'
+          import json
+          import sys
+
+          path = sys.argv[1]
+          try:
+              with open(path, 'r', encoding='utf-8') as f:
+                  payload = json.load(f)
+          except Exception as exc:
+              print(f"::error::GCP_SA_KEY is not valid JSON: {exc}")
+              sys.exit(1)
+
+          required_fields = (
+              "type",
+              "project_id",
+              "private_key_id",
+              "private_key",
+              "client_email",
+              "token_uri",
+          )
+          missing = [field for field in required_fields if not payload.get(field)]
+          if missing:
+              print("::error::GCP_SA_KEY is missing required fields: " + ", ".join(missing))
+              sys.exit(1)
+
+          if payload.get("type") != "service_account":
+              print("::error::GCP_SA_KEY must be a service account JSON key")
+              sys.exit(1)
+
+          print("Deploy auth precheck passed.")
+          PY
+
   cd:
     name: Deploy
-    needs: ci
+    needs: [ci, deploy-auth-precheck]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     uses: theandiman/recipe-management/.github/workflows/backend-java-cloud-run-cd.yml@2d6c963fd364bc373af4c91fdba3cd47b9996258
     permissions:


### PR DESCRIPTION
## Problem Statement
Main-branch post-merge deployments are failing in the reusable CD job during Google Cloud service-account authentication, and the current workflow surfaces this late in the pipeline.

## Scope
- add a deploy auth precheck job in `.github/workflows/ci-cd.yml`
- validate required deploy secrets exist (`GCP_PROJECT_ID`, `GCP_SA_KEY`)
- validate `GCP_SA_KEY` is parseable service-account JSON with required fields
- gate the `Deploy` reusable workflow job on this precheck

## Out of Scope
- changing actual secret values or IAM permissions in GitHub/GCP
- changing reusable workflow logic in `theandiman/recipe-management`

## BDD Scenarios
Scenario 1: Fail fast on missing deploy secrets
- Given a main-branch push where deploy secrets are missing
- When CI/CD runs
- Then `Deploy Auth Precheck` fails immediately with a clear error naming the missing secret
- And `Deploy` does not start

Scenario 2: Fail fast on invalid service-account payload
- Given a main-branch push where `GCP_SA_KEY` is malformed or missing required fields
- When CI/CD runs
- Then `Deploy Auth Precheck` fails with an actionable validation message
- And the failure occurs before Docker build/deploy steps

Scenario 3: Preserve existing successful deploy path
- Given a main-branch push where deploy secrets are valid
- When CI/CD runs
- Then `Deploy Auth Precheck` passes
- And `Deploy` runs with unchanged deployment behavior

## Test Evidence
- Workflow YAML syntax validation: `ruby -ryaml -e "YAML.load_file('.github/workflows/ci-cd.yml')"`
- Local review confirms `Deploy` now depends on `deploy-auth-precheck`

## Risks / Follow-ups
- This PR improves failure visibility and ordering, but does not fix incorrect IAM/secret values.
- If deploy still fails after precheck passes, next step is credential/IAM remediation in secrets/GCP setup.

## Acceptance Checklist
- [x] Explicit precheck exists for deploy auth inputs
- [x] Deploy job is blocked when precheck fails
- [x] Existing CI and deploy flow unchanged when precheck passes
