### PR TITLE
CI: migrate AI service deploy auth to WIF

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,10 +29,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Validate deploy secrets format
+      - name: Validate deploy WIF secrets
         env:
-          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_DEPLOY_SA: ${{ secrets.GCP_DEPLOY_SA }}
         shell: bash
         run: |
           set -euo pipefail
@@ -42,46 +43,27 @@ jobs:
             exit 1
           fi
 
-          if [[ -z "${GCP_SA_KEY:-}" ]]; then
-            echo "::error::Missing required secret: GCP_SA_KEY"
+          if [[ -z "${GCP_WORKLOAD_IDENTITY_PROVIDER:-}" ]]; then
+            echo "::error::Missing required secret: GCP_WORKLOAD_IDENTITY_PROVIDER"
             exit 1
           fi
 
-          sa_file="$(mktemp)"
-          trap 'rm -f "$sa_file"' EXIT
-          printf '%s' "$GCP_SA_KEY" > "$sa_file"
+          if [[ -z "${GCP_DEPLOY_SA:-}" ]]; then
+            echo "::error::Missing required secret: GCP_DEPLOY_SA"
+            exit 1
+          fi
 
-          python - "$sa_file" <<'PY'
-          import json
-          import sys
+          if [[ ! "${GCP_WORKLOAD_IDENTITY_PROVIDER}" =~ ^projects/[0-9]+/locations/global/workloadIdentityPools/.+/providers/.+$ ]]; then
+            echo "::error::GCP_WORKLOAD_IDENTITY_PROVIDER must match projects/<number>/locations/global/workloadIdentityPools/<pool>/providers/<provider>"
+            exit 1
+          fi
 
-          path = sys.argv[1]
-          try:
-              with open(path, 'r', encoding='utf-8') as f:
-                  payload = json.load(f)
-          except Exception as exc:
-              print(f"::error::GCP_SA_KEY is not valid JSON: {exc}")
-              sys.exit(1)
+          if [[ ! "${GCP_DEPLOY_SA}" =~ @.+\.iam\.gserviceaccount\.com$ ]]; then
+            echo "::error::GCP_DEPLOY_SA must be a valid Google service account email"
+            exit 1
+          fi
 
-          required_fields = (
-              "type",
-              "project_id",
-              "private_key_id",
-              "private_key",
-              "client_email",
-              "token_uri",
-          )
-          missing = [field for field in required_fields if not payload.get(field)]
-          if missing:
-              print("::error::GCP_SA_KEY is missing required fields: " + ", ".join(missing))
-              sys.exit(1)
-
-          if payload.get("type") != "service_account":
-              print("::error::GCP_SA_KEY must be a service account JSON key")
-              sys.exit(1)
-
-          print("Deploy auth precheck passed.")
-          PY
+          echo "Deploy auth precheck passed."
 
   cd:
     name: Deploy
@@ -95,6 +77,9 @@ jobs:
     with:
       service_name: recipe-ai-service
       artifact_registry_repository: recipe-ai
+      use_wif: true
     secrets:
-      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_DEPLOY_SA: ${{ secrets.GCP_DEPLOY_SA }}
+      GIT_PAT: ${{ secrets.GIT_PAT }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -78,8 +78,4 @@ jobs:
       service_name: recipe-ai-service
       artifact_registry_repository: recipe-ai
       use_wif: true
-    secrets:
-      GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_DEPLOY_SA: ${{ secrets.GCP_DEPLOY_SA }}
-      GIT_PAT: ${{ secrets.GIT_PAT }}
+    secrets: inherit


### PR DESCRIPTION
## Problem Statement
`recipe-management-ai-service` still deploys with `GCP_SA_KEY`, while the sibling storage service already uses Workload Identity Federation. This leaves AI-service deploys blocked on an invalid key secret even though the platform already supports WIF.

## Scope
- migrate `recipe-management-ai-service` Cloud Run CD wrapper to `use_wif: true`
- replace key-based deploy secret usage with WIF secrets
- update deploy precheck to validate WIF inputs instead of `GCP_SA_KEY`

## Out of Scope
- creating or rotating GitHub/GCP secrets
- changing reusable workflow implementation in `theandiman/recipe-management`
- changing application runtime code or deploy artifact contents

## BDD Scenarios
Scenario 1: Main deploy uses WIF
- Given a main-branch push for `recipe-management-ai-service`
- When the deploy workflow starts
- Then the workflow authenticates through Workload Identity Federation instead of `GCP_SA_KEY`
- And the deploy path no longer depends on a raw service-account JSON key

Scenario 2: Missing WIF config fails fast
- Given a main-branch push where `GCP_WORKLOAD_IDENTITY_PROVIDER` or `GCP_DEPLOY_SA` is missing or malformed
- When CI/CD runs
- Then `Deploy Auth Precheck` fails immediately with a clear validation message
- And the reusable deploy job does not start

Scenario 3: Existing deploy behavior remains intact
- Given valid WIF secrets for the AI service
- When CI/CD runs on main
- Then `Build and Test` continues unchanged
- And the reusable Cloud Run CD workflow receives the same service/repository inputs with WIF enabled

## Test Evidence
- Workflow YAML syntax validation: `ruby -ryaml -e "YAML.load_file('.github/workflows/ci-cd.yml')"`
- Local review confirms `cd` now sets `use_wif: true` and passes WIF secrets plus `GIT_PAT`

## Risks / Follow-ups
- This PR assumes the repository already has valid `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_DEPLOY_SA`, `GCP_PROJECT_ID`, and `GIT_PAT` secrets configured.
- If those secrets are absent or incorrect, the new precheck will fail fast with explicit guidance.

## Acceptance Checklist
- [x] AI-service deploy wrapper uses WIF instead of `GCP_SA_KEY`
- [x] Precheck validates WIF configuration before deploy
- [x] Reusable deploy workflow still receives required project/service inputs
