### PR TITLE
CI: make Docker build robust to artifact jar path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,14 @@ RUN apt-get update && apt-get install -y wget ca-certificates && \
     [ -s opentelemetry-javaagent.jar ] && echo "✅ OpenTelemetry agent downloaded successfully" || (echo "❌ Failed to download OpenTelemetry agent" && exit 1) && \
     apt-get remove -y wget ca-certificates && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Copy jar and set ownership to non-root user
-COPY target/*.jar /home/appuser/app.jar
-RUN chown appuser:appuser /home/appuser/app.jar /home/appuser/opentelemetry-javaagent.jar && \
+# Copy build output and resolve application jar regardless of extraction path
+COPY . /tmp/build-context
+RUN set -e && \
+    jar_path="$(find /tmp/build-context -maxdepth 4 -type f -name 'recipe-generator-service-*.jar' | head -n 1)" && \
+    [ -n "$jar_path" ] && \
+    cp "$jar_path" /home/appuser/app.jar && \
+    rm -rf /tmp/build-context && \
+    chown appuser:appuser /home/appuser/app.jar /home/appuser/opentelemetry-javaagent.jar && \
     chmod 500 /home/appuser/app.jar && \
     chmod 400 /home/appuser/opentelemetry-javaagent.jar
 


### PR DESCRIPTION
## Problem Statement
Main CI/CD deploy fails during Docker build because the runtime stage assumes the jar is always at `target/*.jar`. In workflow artifact download scenarios, file layout can differ, causing `COPY target/*.jar` to fail.

## Scope
- update `Dockerfile` runtime stage to discover the built jar from build context
- keep image runtime behavior unchanged (`/app/app.jar`, same entrypoint)

## Out of Scope
- changing reusable GitHub workflows
- changing Java build outputs
- changing service runtime configuration

## BDD Scenarios
Scenario 1: Deploy artifact layout variance
- Given CI artifacts where jar path is not guaranteed to be exactly `target/*.jar`
- When Docker build runs
- Then the Dockerfile still finds `recipe-generator-service-*.jar`
- And image build succeeds

Scenario 2: Existing happy path
- Given local or CI builds where jar remains under `target/`
- When Docker build runs
- Then image build still succeeds without runtime behavior change

Scenario 3: Regression protection
- Given existing runtime expectations
- When container starts
- Then app still launches using `/app/app.jar` with the same Java agent/entrypoint

## Test Evidence
- Local Docker build passed:
  - `docker build -f Dockerfile -t recipe-ai-service:debug .`

## Risks / Follow-ups
- This intentionally searches for `recipe-generator-service-*.jar`; if artifact naming changes, update the pattern.

## Acceptance Checklist
- [x] Docker build no longer hard-codes `target/*.jar` only
- [x] Runtime entrypoint and app jar location remain unchanged
- [x] Local reproducible build passes
