### PR TITLE
fix: restore WebClient.Builder bean for Cloud Run startup

### DIFF
--- a/src/main/java/com/recipe/ai/config/WebClientConfig.java
+++ b/src/main/java/com/recipe/ai/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package com.recipe.ai.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+}


### PR DESCRIPTION
## Problem
Cloud Run revisions were failing startup with `UnsatisfiedDependencyException` because `WebClient.Builder` was not available for constructor injection in services like `RecipeService`.

## Root Cause
After recent dependency/platform changes, auto-configuration no longer guaranteed a `WebClient.Builder` bean in this app context.

## Fix
- Add explicit Spring config class `WebClientConfig`
- Register a `@Bean` for `WebClient.Builder`

## Validation
- `mvn -DskipTests compile` passes locally

## BDD
- **Given** the app starts in Cloud Run
- **When** Spring creates `RecipeService` and related services requiring `WebClient.Builder`
- **Then** dependency injection succeeds and the application context starts cleanly