### PR TITLE
fix: add explicit ObjectMapper bean for Cloud Run startup

### DIFF
--- a/src/main/java/com/recipe/ai/config/WebClientConfig.java
+++ b/src/main/java/com/recipe/ai/config/WebClientConfig.java
@@ -1,5 +1,6 @@
 package com.recipe.ai.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -10,5 +11,10 @@ public class WebClientConfig {
     @Bean
     public WebClient.Builder webClientBuilder() {
         return WebClient.builder();
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper().findAndRegisterModules();
     }
 }


### PR DESCRIPTION
## Problem
Post-merge `main` deploy still failed at Cloud Run startup after PR #139. Revision logs show:

`Parameter 1 of constructor in com.recipe.ai.service.RecipeService required a bean of type 'com.fasterxml.jackson.databind.ObjectMapper' that could not be found.`

## Fix
- Extend `WebClientConfig` with an explicit Spring `ObjectMapper` bean:
  - `new ObjectMapper().findAndRegisterModules()`

## Validation
- `mvn -DskipTests compile` passes locally

## BDD
- **Given** Cloud Run starts the service and creates `RecipeService`
- **When** constructor injection needs both `WebClient.Builder` and `ObjectMapper`
- **Then** Spring resolves both beans and application context starts
