### PR TITLE
fix: add missing security headers for ZAP parity

### DIFF
--- a/src/main/java/com/recipe/ai/config/SecurityConfig.java
+++ b/src/main/java/com/recipe/ai/config/SecurityConfig.java
@@ -66,11 +66,14 @@ public class SecurityConfig {
 
                     // Security headers for baseline web security checks
                     .headers(headers -> headers
-                        .httpStrictTransportSecurity(hsts -> hsts
-                            .includeSubDomains(true)
-                            .maxAgeInSeconds(31536000))
                         .contentSecurityPolicy(csp -> csp
                             .policyDirectives("default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'"))
+                        .addHeaderWriter(new StaticHeadersWriter(
+                            "Strict-Transport-Security",
+                            "max-age=31536000; includeSubDomains"))
+                        .addHeaderWriter(new StaticHeadersWriter(
+                            "Cross-Origin-Resource-Policy",
+                            "same-origin"))
                         .addHeaderWriter(new StaticHeadersWriter(
                             "Permissions-Policy",
                             "geolocation=(), microphone=(), camera=()")))


### PR DESCRIPTION
## Problem
Latest `main` deploy succeeds, but OWASP ZAP still fails with:
- `WARN-NEW: Strict-Transport-Security Header Not Set [10035]`
- `WARN-NEW: Cross-Origin-Resource-Policy Header Missing or Invalid [90004]`

## Fix
- Add explicit response headers in `SecurityConfig` using `StaticHeadersWriter`:
  - `Strict-Transport-Security: max-age=31536000; includeSubDomains`
  - `Cross-Origin-Resource-Policy: same-origin`
- Keep existing API auth behavior unchanged.

## Validation
- `mvn -DskipTests compile` passes locally.
