### PR TITLE
fix: harden AI recipe response parsing

### DIFF
--- a/src/main/java/com/recipe/ai/controller/RecipeController.java
+++ b/src/main/java/com/recipe/ai/controller/RecipeController.java
@@ -37,14 +37,17 @@ public class RecipeController {
     * @return The generated shared Recipe, or an error response
      */
     @PostMapping("/generate")
-    public ResponseEntity<Recipe> generateRecipe(@RequestBody RecipeGenerationRequest request) {
+    public ResponseEntity<?> generateRecipe(@RequestBody RecipeGenerationRequest request) {
         try {
             Recipe recipe = recipeService.generateRecipeModel(request);
             
             if (recipe != null) {
                 return new ResponseEntity<>(recipe, HttpStatus.OK);
             } else {
-                return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+                return new ResponseEntity<>(
+                    Map.of("message", "AI service returned an invalid recipe response."),
+                    HttpStatus.BAD_GATEWAY
+                );
             }
         } catch (Exception e) {
             log.error("Error generating recipe: {}", e.getMessage(), e);

--- a/src/main/java/com/recipe/ai/service/RecipeService.java
+++ b/src/main/java/com/recipe/ai/service/RecipeService.java
@@ -458,7 +458,7 @@ public class RecipeService {
                 if (content != null) {
                     List<Part> parts = content.getParts();
                     if (parts != null && !parts.isEmpty() && parts.get(0).getText() != null) {
-                        String recipeJson = parts.get(0).getText(); // Final structured JSON recipe string
+                        String recipeJson = normalizeRecipeJson(parts.get(0).getText()); // Final structured JSON recipe string
                         try {
                             // parse and run safety checks before any further processing
                             @SuppressWarnings("unchecked")
@@ -637,10 +637,49 @@ public class RecipeService {
 
         // Parse JSON string into shared Recipe model
         try {
-            return objectMapper.readValue(recipeJson, Recipe.class);
+            return objectMapper.readValue(normalizeRecipeJson(recipeJson), Recipe.class);
         } catch (Exception e) {
             log.error("Failed to parse recipe JSON into DTO: {}", e.getMessage(), e);
             return null;
+        }
+    }
+
+    String normalizeRecipeJson(String candidate) {
+        if (candidate == null) {
+            return null;
+        }
+
+        String trimmed = candidate.trim();
+        if (trimmed.startsWith("```")) {
+            trimmed = trimmed.replaceFirst("^```(?:json)?\\s*", "");
+            trimmed = trimmed.replaceFirst("\\s*```$", "");
+        }
+
+        if (looksLikeJsonObject(trimmed)) {
+            return trimmed;
+        }
+
+        int start = trimmed.indexOf('{');
+        int end = trimmed.lastIndexOf('}');
+        if (start >= 0 && end > start) {
+            String extracted = trimmed.substring(start, end + 1).trim();
+            if (looksLikeJsonObject(extracted)) {
+                return extracted;
+            }
+        }
+
+        return trimmed;
+    }
+
+    private boolean looksLikeJsonObject(String value) {
+        if (value == null || value.isBlank()) {
+            return false;
+        }
+
+        try {
+            return objectMapper.readTree(value).isObject();
+        } catch (Exception e) {
+            return false;
         }
     }
 

--- a/src/main/java/com/recipe/ai/service/RecipeService.java
+++ b/src/main/java/com/recipe/ai/service/RecipeService.java
@@ -651,8 +651,13 @@ public class RecipeService {
 
         String trimmed = candidate.trim();
         if (trimmed.startsWith("```")) {
-            trimmed = trimmed.replaceFirst("^```(?:json)?\\s*", "");
-            trimmed = trimmed.replaceFirst("\\s*```$", "");
+            int firstNewline = trimmed.indexOf('\n');
+            if (firstNewline >= 0) {
+                trimmed = trimmed.substring(firstNewline + 1).trim();
+            }
+            if (trimmed.endsWith("```")) {
+                trimmed = trimmed.substring(0, trimmed.length() - 3).trim();
+            }
         }
 
         if (trimmed.startsWith("{") && trimmed.endsWith("}")) {

--- a/src/main/java/com/recipe/ai/service/RecipeService.java
+++ b/src/main/java/com/recipe/ai/service/RecipeService.java
@@ -637,7 +637,7 @@ public class RecipeService {
 
         // Parse JSON string into shared Recipe model
         try {
-            return objectMapper.readValue(normalizeRecipeJson(recipeJson), Recipe.class);
+            return objectMapper.readValue(recipeJson, Recipe.class);
         } catch (Exception e) {
             log.error("Failed to parse recipe JSON into DTO: {}", e.getMessage(), e);
             return null;
@@ -645,8 +645,8 @@ public class RecipeService {
     }
 
     String normalizeRecipeJson(String candidate) {
-        if (candidate == null) {
-            return null;
+        if (candidate == null || candidate.isBlank()) {
+            return candidate;
         }
 
         String trimmed = candidate.trim();
@@ -655,32 +655,17 @@ public class RecipeService {
             trimmed = trimmed.replaceFirst("\\s*```$", "");
         }
 
-        if (looksLikeJsonObject(trimmed)) {
+        if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
             return trimmed;
         }
 
         int start = trimmed.indexOf('{');
         int end = trimmed.lastIndexOf('}');
         if (start >= 0 && end > start) {
-            String extracted = trimmed.substring(start, end + 1).trim();
-            if (looksLikeJsonObject(extracted)) {
-                return extracted;
-            }
+            return trimmed.substring(start, end + 1).trim();
         }
 
         return trimmed;
-    }
-
-    private boolean looksLikeJsonObject(String value) {
-        if (value == null || value.isBlank()) {
-            return false;
-        }
-
-        try {
-            return objectMapper.readTree(value).isObject();
-        } catch (Exception e) {
-            return false;
-        }
     }
 
     private String createMockRecipe(List<String> pantryItems) {

--- a/src/main/java/com/recipe/ai/service/RecipeService.java
+++ b/src/main/java/com/recipe/ai/service/RecipeService.java
@@ -644,7 +644,7 @@ public class RecipeService {
         }
     }
 
-    String normalizeRecipeJson(String candidate) {
+    private String normalizeRecipeJson(String candidate) {
         if (candidate == null || candidate.isBlank()) {
             return candidate;
         }

--- a/src/test/java/com/recipe/ai/controller/RecipeControllerTest.java
+++ b/src/test/java/com/recipe/ai/controller/RecipeControllerTest.java
@@ -57,16 +57,18 @@ public class RecipeControllerTest {
     }
 
     @Test
-    void generateRecipe_allowsEmptyPrompt_andDelegatesToService() throws Exception {
+    void generateRecipe_allowsEmptyPrompt_andDelegatesToService() {
         RecipeGenerationRequest request = new RecipeGenerationRequest();
         request.setPrompt("");
         request.setPantryItems(List.of());
         
-    ResponseEntity<Recipe> resp = controller.generateRecipe(request);
+        ResponseEntity<?> resp = controller.generateRecipe(request);
 
         assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
-        assertThat(resp.getBody()).isNotNull();
-    assertThat(resp.getBody().getRecipeName()).isEqualTo("Test Recipe");
+        assertThat(resp.getBody()).isInstanceOf(Recipe.class);
+        Recipe body = (Recipe) resp.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.getRecipeName()).isEqualTo("Test Recipe");
     }
 
     @Test

--- a/src/test/java/com/recipe/ai/controller/RecipeControllerTest.java
+++ b/src/test/java/com/recipe/ai/controller/RecipeControllerTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 /**
  * Lightweight unit tests for the controller that avoid starting a Spring context
@@ -66,6 +67,27 @@ public class RecipeControllerTest {
         assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(resp.getBody()).isNotNull();
     assertThat(resp.getBody().getRecipeName()).isEqualTo("Test Recipe");
+    }
+
+    @Test
+    void generateRecipe_returnsBadGatewayWhenServiceReturnsNull() {
+        RecipeController failingController = new RecipeController(new TestRecipeService() {
+            @Override
+            public Recipe generateRecipeModel(RecipeGenerationRequest request) {
+                return null;
+            }
+        });
+        RecipeGenerationRequest request = new RecipeGenerationRequest();
+        request.setPrompt("test");
+        request.setPantryItems(List.of("egg"));
+
+        ResponseEntity<?> resp = failingController.generateRecipe(request);
+
+        assertThat(resp.getStatusCode().value()).isEqualTo(502);
+        assertThat(resp.getBody()).isInstanceOf(Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) resp.getBody();
+        assertThat(body).contains(entry("message", "AI service returned an invalid recipe response."));
     }
 
     @Test

--- a/src/test/java/com/recipe/ai/service/RecipeServiceWebClientTest.java
+++ b/src/test/java/com/recipe/ai/service/RecipeServiceWebClientTest.java
@@ -1,6 +1,7 @@
 package com.recipe.ai.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -104,7 +105,11 @@ public class RecipeServiceWebClientTest {
         keyField.set(service, "TEST_API_KEY");
 
         String out = service.generateRecipe("Make a test", List.of("egg"));
-        assertTrue(out.contains("\"recipeName\":\"Fence Test Recipe\""));
-        assertTrue(out.contains("\"ingredients\":[\"egg\"]"));
+        assertTrue(!out.contains("```"));
+
+        JsonNode json = new ObjectMapper().readTree(out);
+        assertEquals("Fence Test Recipe", json.get("recipeName").asText());
+        assertEquals(1, json.get("ingredients").size());
+        assertEquals("egg", json.get("ingredients").get(0).asText());
     }
 }

--- a/src/test/java/com/recipe/ai/service/RecipeServiceWebClientTest.java
+++ b/src/test/java/com/recipe/ai/service/RecipeServiceWebClientTest.java
@@ -90,7 +90,7 @@ public class RecipeServiceWebClientTest {
         Mockito.when(builder.defaultHeader(Mockito.any(), Mockito.any())).thenReturn(builder);
         Mockito.when(builder.build()).thenReturn(webClient);
 
-        RecipeService service = new RecipeService(builder, new ObjectMapper());
+        RecipeService service = new RecipeService(builder, new ObjectMapper(), new AISuggestionValidator());
 
         java.lang.reflect.Field urlField = RecipeService.class.getDeclaredField("geminiApiUrl");
         urlField.setAccessible(true);

--- a/src/test/java/com/recipe/ai/service/RecipeServiceWebClientTest.java
+++ b/src/test/java/com/recipe/ai/service/RecipeServiceWebClientTest.java
@@ -69,8 +69,20 @@ public class RecipeServiceWebClientTest {
               "instructions": ["Cook it."],
               "servings": 1
             }
-            """.trim().replace("\"", "\\\"");
-        String sample = "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"```json\\n" + recipeJson + "\\n```\"}]}}]}";
+            """.trim();
+        String sample = new ObjectMapper().writeValueAsString(
+            java.util.Map.of(
+                "candidates", java.util.List.of(
+                    java.util.Map.of(
+                        "content", java.util.Map.of(
+                            "parts", java.util.List.of(
+                                java.util.Map.of("text", "```json\n" + recipeJson + "\n```")
+                            )
+                        )
+                    )
+                )
+            )
+        );
 
         org.springframework.web.reactive.function.client.ExchangeFunction exchange = req -> {
             org.springframework.web.reactive.function.client.ClientResponse resp =

--- a/src/test/java/com/recipe/ai/service/RecipeServiceWebClientTest.java
+++ b/src/test/java/com/recipe/ai/service/RecipeServiceWebClientTest.java
@@ -9,6 +9,7 @@ import reactor.core.publisher.Mono;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RecipeServiceWebClientTest {
 
@@ -56,5 +57,54 @@ public class RecipeServiceWebClientTest {
 
         String out = service.generateRecipe("Make a test", List.of("egg"));
         assertEquals("Test recipe text from Gemini.", out.trim());
+    }
+
+    @Test
+    public void testGenerateRecipe_stripsMarkdownFencesFromGeminiResponse() throws Exception {
+        String recipeJson = """
+            {
+              "recipeName": "Fence Test Recipe",
+              "ingredients": ["egg"],
+              "instructions": ["Cook it."],
+              "servings": 1
+            }
+            """.trim().replace("\"", "\\\"");
+        String sample = "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"```json\\n" + recipeJson + "\\n```\"}]}}]}";
+
+        org.springframework.web.reactive.function.client.ExchangeFunction exchange = req -> {
+            org.springframework.web.reactive.function.client.ClientResponse resp =
+                org.springframework.web.reactive.function.client.ClientResponse
+                    .create(org.springframework.http.HttpStatus.OK)
+                    .header("Content-Type", "application/json")
+                    .body(sample)
+                    .build();
+            return Mono.just(resp);
+        };
+
+        WebClient webClient = WebClient.builder().exchangeFunction(exchange).build();
+        WebClient.Builder builder = Mockito.mock(WebClient.Builder.class);
+        Mockito.when(builder.baseUrl(Mockito.any())).thenReturn(builder);
+        Mockito.when(builder.clientConnector(Mockito.any(org.springframework.http.client.reactive.ClientHttpConnector.class))).thenReturn(builder);
+        Mockito.when(builder.exchangeStrategies(Mockito.any(org.springframework.web.reactive.function.client.ExchangeStrategies.class))).thenReturn(builder);
+        Mockito.when(builder.defaultHeader(Mockito.any(), Mockito.any())).thenReturn(builder);
+        Mockito.when(builder.build()).thenReturn(webClient);
+
+        RecipeService service = new RecipeService(builder, new ObjectMapper());
+
+        java.lang.reflect.Field urlField = RecipeService.class.getDeclaredField("geminiApiUrl");
+        urlField.setAccessible(true);
+        urlField.set(service, "https://example.com/mock");
+
+        java.lang.reflect.Field promptField = RecipeService.class.getDeclaredField("systemPrompt");
+        promptField.setAccessible(true);
+        promptField.set(service, "You are a test chef.");
+
+        java.lang.reflect.Field keyField = RecipeService.class.getDeclaredField("geminiApiKey");
+        keyField.setAccessible(true);
+        keyField.set(service, "TEST_API_KEY");
+
+        String out = service.generateRecipe("Make a test", List.of("egg"));
+        assertTrue(out.contains("\"recipeName\":\"Fence Test Recipe\""));
+        assertTrue(out.contains("\"ingredients\":[\"egg\"]"));
     }
 }


### PR DESCRIPTION
## Summary
- normalize fenced or wrapped Gemini recipe JSON before parsing it into the shared recipe model
- return a controlled `502` response when the upstream AI response is still invalid instead of collapsing into a generic `500`
- add regression coverage for fenced JSON and controller handling when parsing fails

## Validation
- `mvn -q -DskipTests compile`
- focused service/controller test coverage added in code
- full test compilation is currently blocked by the existing `OpenApiGeneratorTest` dependency issue outside this PR